### PR TITLE
Explicitly differentiate between noclip movement and spectator movement

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -481,6 +481,7 @@ typedef enum {
     PM_HOOK_PULL,   // Pull hook
     PM_HOOK_SWING,  // Swing hook
     PM_SPECTATOR,   // Free-flying movement with acceleration and friction
+    PM_NOCLIP,      // Like PM_SPECTATOR, but noclips through walls
     // All slots up till 32 are free for custom game PM_ defines.
     PM_DEAD = 32, // No movement, but the ability to rotate in place
     PM_FREEZE,    // No movement at all

--- a/src/clgame/clg_predict.cpp
+++ b/src/clgame/clg_predict.cpp
@@ -309,7 +309,7 @@ void CLG_PredictMovement(unsigned int ack, unsigned int current) {
     //    }
     //}
 
-    if (pm.state.type != PM_SPECTATOR) {
+    if (pm.state.type != PM_SPECTATOR || pm.state.type != PM_NOCLIP) {
         oldz = cl->predicted_origins[cl->predicted_step_frame & CMD_MASK][2];
         step = pm.state.origin[2] - oldz;
 

--- a/src/svgame/g_local.h
+++ b/src/svgame/g_local.h
@@ -184,6 +184,7 @@ typedef enum {
 // edict->moveType values
 typedef enum {
     MOVETYPE_NONE,          // never moves
+    MOVETYPE_SPECTATOR,     // special movetype for spectators to not go through walls
     MOVETYPE_NOCLIP,        // origin and angles change with no interaction
     MOVETYPE_PUSH,          // no clip to world, push on box contact
     MOVETYPE_STOP,          // no clip to world, stops on box contact

--- a/src/svgame/physics.cpp
+++ b/src/svgame/physics.cpp
@@ -428,7 +428,8 @@ qboolean SV_Push(entity_t *pusher, vec3_t move, vec3_t amove)
         if (check->moveType == MOVETYPE_PUSH
             || check->moveType == MOVETYPE_STOP
             || check->moveType == MOVETYPE_NONE
-            || check->moveType == MOVETYPE_NOCLIP)
+            || check->moveType == MOVETYPE_NOCLIP
+            || check->moveType == MOVETYPE_SPECTATOR)
             continue;
 
         if (!check->area.prev)
@@ -905,6 +906,7 @@ void G_RunEntity(entity_t *ent)
         SV_Physics_None(ent);
         break;
     case MOVETYPE_NOCLIP:
+    case MOVETYPE_SPECTATOR:
         SV_Physics_Noclip(ent);
         break;
     case MOVETYPE_STEP:

--- a/src/svgame/player/client.cpp
+++ b/src/svgame/player/client.cpp
@@ -733,7 +733,7 @@ void RespawnClient(entity_t *self)
 {
     if (deathmatch->value || coop->value) {
         // spectator's don't leave bodies
-        if (self->moveType != MOVETYPE_NOCLIP)
+        if (self->moveType != MOVETYPE_NOCLIP && self->moveType != MOVETYPE_SPECTATOR)
             CopyToBodyQue(self);
         self->svFlags &= ~SVF_NOCLIENT;
         PutClientInServer(self);
@@ -986,7 +986,7 @@ void PutClientInServer(entity_t *ent)
 
         client->resp.spectator = true;
 
-        ent->moveType = MOVETYPE_NOCLIP;
+        ent->moveType = MOVETYPE_SPECTATOR;
         ent->solid = Solid::Not;
         ent->svFlags |= SVF_NOCLIENT;
         ent->client->playerState.gunindex = 0;
@@ -1347,11 +1347,13 @@ void ClientThink(entity_t *ent, usercmd_t *ucmd)
         // set up for pmove
         memset(&pm, 0, sizeof(pm));
 
-        if (ent->moveType == MOVETYPE_NOCLIP)
+        if ( ent->moveType == MOVETYPE_NOCLIP )
+            client->playerState.pmove.type = PM_NOCLIP;
+        else if ( ent->moveType == MOVETYPE_SPECTATOR )
             client->playerState.pmove.type = PM_SPECTATOR;
-        else if (ent->s.modelindex != 255)
+        else if ( ent->s.modelindex != 255 )
             client->playerState.pmove.type = PM_GIB;
-        else if (ent->deadFlag)
+        else if ( ent->deadFlag )
             client->playerState.pmove.type = PM_DEAD;
         else
             client->playerState.pmove.type = PM_NORMAL;
@@ -1418,7 +1420,7 @@ void ClientThink(entity_t *ent, usercmd_t *ucmd)
 
         gi.LinkEntity(ent);
 
-        if (ent->moveType != MOVETYPE_NOCLIP)
+        if (ent->moveType != MOVETYPE_NOCLIP && ent->moveType != MOVETYPE_SPECTATOR)
             UTIL_TouchTriggers(ent);
 
         // touch other objects

--- a/src/svgame/player/view.cpp
+++ b/src/svgame/player/view.cpp
@@ -435,7 +435,7 @@ static void P_CheckFallingDamage(entity_t *ent)
     if (ent->s.modelindex != 255)
         return;     // not in the player model
 
-    if (ent->moveType == MOVETYPE_NOCLIP)
+    if (ent->moveType == MOVETYPE_NOCLIP || ent->moveType == MOVETYPE_SPECTATOR)
         return;
 
     if ((ent->client->oldVelocity[2] < 0) && (ent->velocity[2] > ent->client->oldVelocity[2]) && (!ent->groundEntityPtr)) {
@@ -499,7 +499,7 @@ static void P_CheckWorldEffects(void)
 {
     int         waterlevel, old_waterlevel;
 
-    if (current_player->moveType == MOVETYPE_NOCLIP) {
+    if (current_player->moveType == MOVETYPE_NOCLIP || current_player->moveType == MOVETYPE_SPECTATOR) {
         current_player->air_finished = level.time + 12; // don't need air
         return;
     }


### PR DESCRIPTION
With this PR, the player will fly *through* walls as opposed to colliding against them while using the noclip command. Spectators (and whichever flying AI might use MOVETYPE_SPECTATOR) will still collide against solids.