### PR TITLE
Runtime type information system; func_door draft; overhauled spawning system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,9 @@ SET ( HEADERS_SVGAME_ENTITIES_FUNC
 	svgame/entities/func/FuncButton.h
 	svgame/entities/func/FuncDoor.h
 )
+SET ( HEADERS_SVGAME_ENTITIES_INFO 
+	svgame/entities/info/InfoPlayerStart.h
+)
 SET ( HEADERS_SVGAME_ENTITIES_MISC 
 	svgame/entities/misc/MiscExplosionBox.h
 )
@@ -234,7 +237,7 @@ SET ( HEADERS_SVGAME_ENTITIES
 )
 SET ( HEADERS_SVGAME_GAMEMODES 
 	svgame/gamemodes/DefaultGameMode.h
-	svgame/gamemodes/CoopGameMode.cpp
+	svgame/gamemodes/CoopGameMode.h
 	svgame/gamemodes/DeathMatchGameMode.h
 	svgame/gamemodes/IGameMode.h
 )
@@ -258,10 +261,12 @@ SET(HEADERS_SVGAME
 	${HEADERS_SVGAME_MAIN}
 	${HEADERS_SVGAME_ENTITIES_BASE}
 	${HEADERS_SVGAME_ENTITIES_FUNC}
+	${HEADERS_SVGAME_ENTITIES_INFO}
 	${HEADERS_SVGAME_ENTITIES_MISC}
 	${HEADERS_SVGAME_ENTITIES_TRIGGER} 
 	${HEADERS_SVGAME_ENTITIES_WEAPONRY}
 	${HEADERS_SVGAME_ENTITIES}
+	${HEADERS_SVGAME_GAMEMODES}
 	${HEADERS_SVGAME_PLAYER}
 	${HEADERS_SVGAME_WEAPONS}
 )
@@ -739,6 +744,7 @@ SOURCE_GROUP("source\\entities\\misc"		FILES ${SRC_SVGAME_ENTITIES_MISC} )
 SOURCE_GROUP("source\\entities\\target"		FILES ${SRC_SVGAME_ENTITIES_TARGET} )
 SOURCE_GROUP("source\\entities\\trigger"	FILES ${SRC_SVGAME_ENTITIES_TRIGGER} )
 SOURCE_GROUP("source\\entities\\weaponry"	FILES ${SRC_SVGAME_ENTITIES_WEAPONRY} )
+SOURCE_GROUP("source\\gamemodes"			FILES ${SRC_SVGAME_GAMEMODES} )
 SOURCE_GROUP("source\\physics"				FILES ${SRC_SVGAME_PHYSICS} )
 SOURCE_GROUP("source\\player"				FILES ${SRC_SVGAME_PLAYER} )
 SOURCE_GROUP("source\\weapons"				FILES ${SRC_SVGAME_WEAPONS} )
@@ -748,9 +754,11 @@ SOURCE_GROUP("source\\entities"				FILES ${HEADERS_SVGAME_ENTITIES} )
 SOURCE_GROUP("source\\entities\\ai"			FILES ${HEADERS_SVGAME_ENTITIES_AI} )
 SOURCE_GROUP("source\\entities\\base"		FILES ${HEADERS_SVGAME_ENTITIES_BASE} )
 SOURCE_GROUP("source\\entities\\func"		FILES ${HEADERS_SVGAME_ENTITIES_FUNC} )
+SOURCE_GROUP("source\\entities\\info"		FILES ${HEADERS_SVGAME_ENTITIES_INFO} )
 SOURCE_GROUP("source\\entities\\misc"		FILES ${HEADERS_SVGAME_ENTITIES_MISC} )
 SOURCE_GROUP("source\\entities\\trigger"	FILES ${HEADERS_SVGAME_ENTITIES_TRIGGER} )
 SOURCE_GROUP("source\\entities\\weaponry"	FILES ${HEADERS_SVGAME_ENTITIES_WEAPONRY} )
+SOURCE_GROUP("source\\gamemodes"			FILES ${HEADERS_SVGAME_GAMEMODES} )
 SOURCE_GROUP("source\\player"				FILES ${HEADERS_SVGAME_PLAYER} )
 SOURCE_GROUP("source\\weapons"				FILES ${HEADERS_SVGAME_WEAPONS} )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ SET( SRC_SVGAME_ENTITIES_FUNC
 	#svgame/entities/func/FuncAreaportal.cpp
 	svgame/entities/func/FuncButton.cpp
 	#svgame/entities/func/FuncConveyor.cpp
-	#svgame/entities/func/FuncDoor.cpp 
+	svgame/entities/func/FuncDoor.cpp 
 	#svgame/entities/func/FuncDoorRotating.cpp
 	#svgame/entities/func/FuncExplosive.cpp 
 	#svgame/entities/func/FuncKillbox.cpp
@@ -127,6 +127,7 @@ SET ( SRC_SVGAME_ENTITIES_TRIGGER
 	#svgame/entities/trigger/TriggerPush.cpp
 	#svgame/entities/trigger/TriggerRelay.cpp
 	svgame/entities/trigger/TriggerAlways.cpp
+	svgame/entities/trigger/TriggerAutoDoor.cpp
 	svgame/entities/trigger/TriggerDelayedUse.cpp
 	svgame/entities/trigger/TriggerHurt.cpp
 	svgame/entities/trigger/TriggerMultiple.cpp
@@ -208,12 +209,14 @@ SET ( HEADERS_SVGAME_ENTITIES_BASE
 SET ( HEADERS_SVGAME_ENTITIES_FUNC
 	svgame/entities/func/func_door.h
 	svgame/entities/func/FuncButton.h
+	svgame/entities/func/FuncDoor.h
 )
 SET ( HEADERS_SVGAME_ENTITIES_MISC 
 	svgame/entities/misc/MiscExplosionBox.h
 )
 SET ( HEADERS_SVGAME_ENTITIES_TRIGGER 
 	svgame/entities/trigger/TriggerAlways.h
+	svgame/entities/trigger/TriggerAutoDoor.h
 	svgame/entities/trigger/TriggerDelayedUse.h
 	svgame/entities/trigger/TriggerHurt.h
 	svgame/entities/trigger/TriggerMultiple.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,6 +197,7 @@ SET ( HEADERS_SVGAME_MAIN
 	svgame/entities.h
 	svgame/functionpointers.h
 	svgame/trigger.h
+	svgame/TypeInfo.h
 	svgame/utils.h
 )
 SET ( HEADERS_SVGAME_AI 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -679,7 +679,7 @@ ELSE()
 	TARGET_SOURCES(client PRIVATE ${SRC_CLIENT_RMLUI})
 ENDIF()
 
-if (GLSLANG_COMPILER)
+if (GLSLANG_COMPILER AND CONFIG_VKPT_RENDERER)
 	add_dependencies(client shaders)
 endif()
 

--- a/src/svgame/TypeInfo.h
+++ b/src/svgame/TypeInfo.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <string>
+
+class SVGBaseEntity;
+typedef entity_s Entity;
+
+//===============
+// A static counter, used by TypeInfo to get compile-time IDs
+//===============
+class StaticCounter {
+public:
+	StaticCounter() {
+		localID = GlobalID;
+		GlobalID++;
+	}
+
+    // You can also use this to check the total number of classes
+	inline static size_t GlobalID = 0U;
+
+	size_t GetID() const {
+		return localID;
+	}
+
+private:
+	size_t localID; 
+};
+
+using EntityAllocatorFn = SVGBaseEntity* ( Entity* );
+
+//===============
+// TypeInfo, a system for getting runtime information about classes
+//===============
+class TypeInfo {
+public:
+	TypeInfo( const char* mapClassName, const char* entClassName, const char* superClassName, EntityAllocatorFn entityAllocator )
+		: mapClass( mapClassName ), className( entClassName ), superName( superClassName ) {
+		AllocateInstance = entityAllocator;
+		prev = head;
+		head = this;
+
+		// Doesn't actually quite work here, so I wrote SetupSuperClasses
+		super = GetInfoByName( superClassName );
+	}
+
+	// This will be used to allocate instances of each entity class
+	// In theory, multiple map classnames can allocate one C++ class
+	EntityAllocatorFn* AllocateInstance;
+
+	// Is this entity of this specific class?
+	bool IsClass( const TypeInfo& eci ) const {
+		return classInfoID.GetID() == eci.classInfoID.GetID();
+	}
+
+	// Is this entity a subclass of this class?
+	bool IsSubclassOf( const TypeInfo& eci ) const {
+		if ( nullptr == super )
+			return false;
+
+		if ( classInfoID.GetID() == eci.classInfoID.GetID() )
+			return true;
+
+		return super->IsSubclassOf( eci );
+	}
+
+	// Get type info by map classname
+	static TypeInfo* GetInfoByMapName( const char* name ) { 
+		TypeInfo* current = nullptr;
+		current = head;
+
+		while ( current ) {
+			if ( !strcmp( current->mapClass, name ) ) {
+				return current;
+            }
+			current = current->prev;
+		}
+
+		return nullptr;
+	}
+
+	// Get type info by name
+	static TypeInfo* GetInfoByName( const char* name ) {
+		TypeInfo* current = nullptr;
+		current = head;
+
+		while ( current ) {
+			if ( !strcmp( current->className, name ) ) {
+				return current;
+            }
+			current = current->prev;
+		}
+
+		return nullptr;
+	}
+
+	// This is called during game initialisation to properly set all superclasses
+	static void SetupSuperClasses() {
+		TypeInfo* current = nullptr;
+		current = head;
+
+		while ( current ) {
+			current->super = GetInfoByName( current->superName );
+			current = current->prev;
+		}
+	}
+
+	TypeInfo*       prev;
+	inline static TypeInfo* head = nullptr;
+
+	StaticCounter   classInfoID; // automatically increments itself; TODO: maybe generate a CRC32 for each classname instead?
+	TypeInfo*       super;
+
+	const char*     mapClass;
+	const char*     className;
+	const char*     superName;
+};
+
+// ========================================================================
+// Welcome to macro abuse purgatory, a.k.a. M.A.P.
+// TODO: rewrite these macros using templates? It'd be quite nicer that way
+// ========================================================================
+
+// Declares and initialises the type information for a class
+// @param mapClassName - the map classname of this entity, used during entity spawning
+// @param className - the internal C++ class name
+#define __DeclareTypeInfo( mapClassName, className, superClass, allocatorFunction )	\
+virtual TypeInfo* GetTypeInfo() {								\
+	return &ClassInfo;											\
+}																\
+inline static TypeInfo ClassInfo = TypeInfo( (mapClassName), (className), (superClass), (allocatorFunction) );
+
+// Top abstract class, the start of the class tree
+// Instances of this cannot be allocated, as it is abstract
+#define DefineTopAbstractClass( className )						\
+__DeclareTypeInfo( #className "_abs", #className, "none", nullptr );
+
+// Abstract class that inherits from another
+// Instances of this cannot be allocated
+// NOTE: multiple inheritance not supported
+#define DefineAbstractClass( className, superClass )			\
+using Base = superClass;										\
+__DeclareTypeInfo( #className "_abs", #className, #superClass, nullptr );
+
+// Declares and initialises the type information for this class, so it can be spawned in a map. 
+// NOTE: multiple inheritance not supported
+// @param mapClassName (string) - the map classname of this entity, used during entity spawning
+// @param className (symbol) - the internal C++ class name
+// @param superClass (symbol) - the class this entity class inherits from
+#define DefineMapClass( mapClassName, className, superClass )	\
+using Base = superClass;										\
+static SVGBaseEntity* AllocateInstance( Entity* entity ) {		\
+	return new className( entity );								\
+}																\
+__DeclareTypeInfo( mapClassName, #className, #superClass, &className::AllocateInstance );
+
+// Declares and initialises the type information for this class
+// NOTE: multiple inheritance not supported
+// @param className (symbol) - the internal C++ class name
+// @param superClass (symbol) - the class this entity class inherits from
+#define DefineClass( className, superClass )					\
+using Base = superClass;										\
+static SVGBaseEntity* AllocateInstance( Entity* entity ) {		\
+	return new className( entity );								\
+}																\
+__DeclareTypeInfo( #className "_dyn", #className, #superClass, &className::AllocateInstance );

--- a/src/svgame/entities.cpp
+++ b/src/svgame/entities.cpp
@@ -40,41 +40,29 @@
 SVGBaseEntity* SVG_SpawnClassEntity(Entity* ent, const std::string& className) {
     // Start with a nice nullptr.
     SVGBaseEntity* spawnEntity = nullptr;
-
-    if (!ent)
+    if ( nullptr == ent ) {
         return nullptr;
+    }
 
     // Fetch entity number.
     int32_t entityNumber = ent->state.number;
 
-    if (className == "misc_explobox")
-        spawnEntity = g_baseEntities[entityNumber] = new MiscExplosionBox(ent);
-    else if (className == "info_player_start")
-        spawnEntity = g_baseEntities[entityNumber] = new InfoPlayerStart(ent);
-    else if (className == "light")
-        spawnEntity = g_baseEntities[entityNumber] = new Light(ent);
-    else if (className == "worldspawn")
-        spawnEntity = g_baseEntities[entityNumber] = new WorldSpawn(ent);
-    else if (className == "trigger_always")
-        spawnEntity = g_baseEntities[entityNumber] = new TriggerAlways(ent);
-    else if (className == "DelayedUse")
-        spawnEntity = g_baseEntities[entityNumber] = new TriggerDelayedUse(ent);
-    else if (className == "trigger_hurt")
-        spawnEntity = g_baseEntities[entityNumber] = new TriggerHurt(ent);
-    else if (className == "trigger_multiple")
-        spawnEntity = g_baseEntities[entityNumber] = new TriggerMultiple(ent);
-    else if (className == "trigger_once")
-        spawnEntity = g_baseEntities[entityNumber] = new TriggerOnce(ent);
-    else if (className == "PlayerClient")
-        spawnEntity = g_baseEntities[entityNumber] = new PlayerClient(ent);
-    else if (className == "BlasterBolt")
-        spawnEntity = g_baseEntities[entityNumber] = new BlasterBolt(ent);
-    else if ( className == "func_button" )
-        spawnEntity = g_baseEntities[entityNumber] = new FuncButton( ent );
-    else
-        spawnEntity = g_baseEntities[entityNumber] = new SVGBaseEntity(ent);
-
-    return spawnEntity;
+    // New type info-based spawning system, to replace endless string comparisons
+    // First find it by the map name
+    TypeInfo* info = TypeInfo::GetInfoByMapName( className.c_str() );
+    if ( nullptr == info ) { // Then try finding it by the C++ class name
+        if ( nullptr == (info = TypeInfo::GetInfoByName( className.c_str() )) ) { 
+            gi.DPrintf( "WARNING: unknown entity '%s'\n", className.c_str() );
+            return nullptr; // Bail out, we didn't find one
+        }
+    }
+    // Don't freak out if the entity cannot be allocated, but do warn us about it, it's good to know
+    if ( nullptr != info->AllocateInstance ) {
+        return (g_baseEntities[entityNumber] = info->AllocateInstance( ent ));
+    } else {
+        gi.DPrintf( "WARNING: tried to allocate an abstract class '%s'\n", info->className );
+        return nullptr;
+    }
 }
 
 //

--- a/src/svgame/entities.h
+++ b/src/svgame/entities.h
@@ -40,6 +40,29 @@ Entity* SVG_Spawn(void);
 
 Entity* SVG_CreateTargetChangeLevel(char* map);
 
+// Admer: quick little template function to spawn entities, until we have this code in a local game class :)
+template<typename entityClass>
+inline entityClass* SVG_CreateEntity() {
+    entityClass* entity = nullptr;
+    Entity* edict = SVG_Spawn();
+    // If we can't spawn the thing, then let go
+    if ( nullptr == edict ) {
+        return nullptr;
+    }
+    // Abstract classes will have AllocateInstance as nullptr, hence we gotta check for that
+    if ( entityClass::ClassInfo.AllocateInstance ) {
+        entity = static_cast<entityClass*>( entityClass::ClassInfo.AllocateInstance( edict ) ); // Entities that aren't in the type info system will error out here
+        edict->className = entity->GetTypeInfo()->className;
+        edict->classEntity = entity;
+        if ( nullptr == g_baseEntities[edict->state.number] ) {
+            g_baseEntities[edict->state.number] = entity;
+        } else {
+            gi.DPrintf( "ERROR: edict %i is already taken\n", edict->state.number );
+        }
+    }
+    return entity;
+}
+
 //
 // ClassEntity handling.
 //

--- a/src/svgame/entities/Light.h
+++ b/src/svgame/entities/Light.h
@@ -18,6 +18,8 @@ public:
     Light(Entity* svEntity);
     virtual ~Light();
 
+    DefineMapClass( "light", Light, SVGBaseTrigger );
+
     //
     // Interface functions. 
     //

--- a/src/svgame/entities/WorldSpawn.cpp
+++ b/src/svgame/entities/WorldSpawn.cpp
@@ -165,7 +165,7 @@ WorldSpawn::~WorldSpawn() {
 //
 void WorldSpawn::Precache() {
     // Parent class precache.
-    SVGBaseEntity::Precache();
+    Base::Precache();
 
     // help icon for statusbar
     SVG_PrecacheImage("i_help");
@@ -270,7 +270,7 @@ void WorldSpawn::Precache() {
 //
 void WorldSpawn::Spawn() {
     // Parent class spawn.
-    SVGBaseEntity::Spawn();
+    Base::Spawn();
 
     // Set WorldSpawn specific properties.
     SetMoveType(MoveType::Push);
@@ -360,7 +360,7 @@ void WorldSpawn::Spawn() {
 //
 void WorldSpawn::PostSpawn() {
     // Parent class PostSpawn.
-    SVGBaseEntity::PostSpawn();
+    Base::PostSpawn();
 }
 
 //
@@ -372,7 +372,7 @@ void WorldSpawn::PostSpawn() {
 //
 void WorldSpawn::Think() {
     // Parent class think.
-    SVGBaseEntity::Think();
+    Base::Think();
 }
 
 //
@@ -449,7 +449,7 @@ void WorldSpawn::SpawnKey(const std::string& key, const std::string& value) {
         SVG_SetConfigString(ConfigStrings::CdTrack, va("%i", sounds));
     } else {
         // Pass it on.
-        SVGBaseEntity::SpawnKey(key, value);
+        Base::SpawnKey(key, value);
     }
 }
 

--- a/src/svgame/entities/WorldSpawn.h
+++ b/src/svgame/entities/WorldSpawn.h
@@ -18,6 +18,8 @@ public:
     WorldSpawn(Entity* svEntity);
     virtual ~WorldSpawn();
 
+    DefineMapClass( "worldspawn", WorldSpawn, SVGBaseEntity );
+
     //
     // Interface functions. 
     //

--- a/src/svgame/entities/base/PlayerClient.cpp
+++ b/src/svgame/entities/base/PlayerClient.cpp
@@ -33,7 +33,7 @@ PlayerClient::~PlayerClient() {
 //===============
 //
 void PlayerClient::Precache() {
-    SVGBaseEntity::Precache();
+    Base::Precache();
 }
 
 //
@@ -44,7 +44,7 @@ void PlayerClient::Precache() {
 //
 void PlayerClient::Spawn() {
     // Spawn.
-    SVGBaseEntity::Spawn();
+    Base::Spawn();
 
     // When spawned, we aren't on any ground, make sure of that.
     SetGroundEntity(nullptr);
@@ -100,7 +100,7 @@ void PlayerClient::Respawn() {
 //===============
 //
 void PlayerClient::PostSpawn() {
-    SVGBaseEntity::PostSpawn();
+    Base::PostSpawn();
 }
 
 //
@@ -111,7 +111,7 @@ void PlayerClient::PostSpawn() {
 //
 void PlayerClient::Think() {
     // Parent class Think.
-    SVGBaseEntity::Think();
+    Base::Think();
 }
 
 //
@@ -123,7 +123,7 @@ void PlayerClient::Think() {
 //
 void PlayerClient::SpawnKey(const std::string& key, const std::string& value) {
     // Parent class spawnkey.
-    SVGBaseEntity::SpawnKey(key, value);
+    Base::SpawnKey(key, value);
 }
 
 //

--- a/src/svgame/entities/base/PlayerClient.h
+++ b/src/svgame/entities/base/PlayerClient.h
@@ -17,6 +17,8 @@ public:
     PlayerClient(Entity* svEntity);
     virtual ~PlayerClient();
 
+    DefineClass( PlayerClient, SVGBaseEntity );
+
     //
     // Interface functions. 
     //

--- a/src/svgame/entities/base/SVGBaseEntity.cpp
+++ b/src/svgame/entities/base/SVGBaseEntity.cpp
@@ -437,13 +437,10 @@ void SVGBaseEntity::UseTargets( SVGBaseEntity* activatorOverride )
 	// Create a temporary DelayedUse entity in case this entity has a trigger delay
 	if ( GetDelayTime() )
 	{
-		Entity* serverTriggerDelay = SVG_Spawn();
-		serverTriggerDelay->className = "DelayedUse";
-
 		// This is all very lengthy. I'd rather have a static method in TriggerDelayedUse that
 		// allocates one such entity and accepts activator, message, target etc. as parameters
 		// Something like 'TriggerDelayedUse::Schedule( GetTarget(), GetKillTarget(), activatorOverride, GetMessage(), GetDelayTime() );'
-		SVGBaseTrigger* triggerDelay = static_cast<SVGBaseTrigger*>(serverTriggerDelay->classEntity = SVG_SpawnClassEntity( serverTriggerDelay, "DelayedUse" ));
+		SVGBaseTrigger* triggerDelay = SVG_CreateEntity<TriggerDelayedUse>();
 		triggerDelay->SetActivator( activatorOverride );
 		triggerDelay->SetMessage( GetMessage() );
 		triggerDelay->SetTarget( GetTarget() );
@@ -554,5 +551,6 @@ void SVGBaseEntity::Remove()
 //
 //
 void SVGBaseEntity::SVGBaseEntityThinkFree(void) {
-	SVG_FreeEntity(serverEntity);
+	//SVG_FreeEntity(serverEntity);
+	Remove();
 }

--- a/src/svgame/entities/base/SVGBaseEntity.h
+++ b/src/svgame/entities/base/SVGBaseEntity.h
@@ -11,6 +11,10 @@
 #ifndef __SVGAME_ENTITIES_BASE_SVGBASEENTITY_H__
 #define __SVGAME_ENTITIES_BASE_SVGBASEENTITY_H__
 
+// It makes sense to include TypeInfo in SVGBaseEntity.h, 
+// because this class absolutely requires it
+#include "../../TypeInfo.h"
+
 class SVGBaseEntity {
 public:
     //
@@ -29,6 +33,22 @@ public:
     SVGBaseEntity(Entity* svEntity);
     virtual ~SVGBaseEntity();
 
+    // Runtime type information
+    DefineTopAbstractClass( SVGBaseEntity );
+
+    // Checks if this entity class is exactly the given class
+    // @param entityClass: an entity class which must inherint from SVGBaseEntity
+    template<typename entityClass>
+    bool IsClass() { // every entity has a ClassInfo, thanks to the DefineXYZ macro
+        return ClassInfo->IsClass( entityClass::ClassInfo );
+    }
+
+    // Checks if this entity class is a subclass of another, or is the same class
+    // @param entityClass: an entity class which must inherint from SVGBaseEntity
+    template<typename entityClass>
+    bool IsSubclassOf() {
+        return ClassInfo->IsSubclassOf( entityClass::ClassInfo );
+    }
 
     //
     // Interface functions. 

--- a/src/svgame/entities/base/SVGBaseMover.cpp
+++ b/src/svgame/entities/base/SVGBaseMover.cpp
@@ -55,7 +55,7 @@ SVGBaseMover::~SVGBaseMover() {
 //===============
 //
 void SVGBaseMover::Precache() {
-	SVGBaseEntity::Precache();
+	Base::Precache();
 }
 
 //
@@ -65,7 +65,7 @@ void SVGBaseMover::Precache() {
 //===============
 //
 void SVGBaseMover::Spawn() {
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 
 }
@@ -77,7 +77,7 @@ void SVGBaseMover::Spawn() {
 //===============
 //
 void SVGBaseMover::Respawn() {
-	SVGBaseTrigger::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -87,7 +87,7 @@ void SVGBaseMover::Respawn() {
 //===============
 //
 void SVGBaseMover::PostSpawn() {
-	SVGBaseTrigger::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -97,7 +97,7 @@ void SVGBaseMover::PostSpawn() {
 //===============
 //
 void SVGBaseMover::Think() {
-	SVGBaseTrigger::Think();
+	Base::Think();
 }
 
 //
@@ -112,7 +112,7 @@ void SVGBaseMover::SpawnKey(const std::string& key, const std::string& value) {
 	} else if ( key == "lip" ) {
 		ParseFloatKeyValue( key, value, lip );
 	} else {
-		SVGBaseTrigger::SpawnKey(key, value);
+		Base::SpawnKey(key, value);
 	}
 }
 

--- a/src/svgame/entities/base/SVGBaseMover.cpp
+++ b/src/svgame/entities/base/SVGBaseMover.cpp
@@ -107,19 +107,11 @@ void SVGBaseMover::Think() {
 //===============
 //
 void SVGBaseMover::SpawnKey(const std::string& key, const std::string& value) {
-	// Wait.
 	if (key == "wait") {
-		// Parsed float.
-		float parsedFloat = 0.f;
-
-		// Parse.
-		ParseFloatKeyValue(key, value, parsedFloat);
-
-		// Assign.
-		SetWaitTime(parsedFloat);
-	}
-	// Parent class spawnkey.
-	else {
+		ParseFloatKeyValue(key, value, waitTime);
+	} else if ( key == "lip" ) {
+		ParseFloatKeyValue( key, value, lip );
+	} else {
 		SVGBaseTrigger::SpawnKey(key, value);
 	}
 }
@@ -155,5 +147,33 @@ void SVGBaseMover::SetMoveDirection(const vec3_t& angles) {
 		AngleVectors(angles, &moveDirection, NULL, NULL);
 	}
 
+	// Admer: is this really intended? Some entities may control their angle
+	// and align it directly with the movement direction.
+	// I suggest we add a bool parameter to this method, 'resetAngles',
+	// which will zero the entity's angles if true
 	SetAngles(vec3_zero());
+}
+
+//===============
+// SVGBaseMover::CalculateEndPosition
+//===============
+vec3_t SVGBaseMover::CalculateEndPosition() {
+	const vec3_t& size = GetSize();
+	vec3_t absoluteDir{
+		fabsf( moveDirection.x ),
+		fabsf( moveDirection.y ),
+		fabsf( moveDirection.z ) 
+	};
+	
+	float distance = (absoluteDir.x * size.x) + (absoluteDir.y * size.y) + (absoluteDir.z * size.z) - GetLip();
+	return vec3_fmaf( GetStartPosition(), distance, moveDirection );
+}
+
+//===============
+// SVGBaseMover::SwapPositions
+//===============
+void SVGBaseMover::SwapPositions() {
+	SetOrigin( GetEndPosition() );			// origin = endpos
+	SetEndPosition( GetStartPosition() );	// endpos = startpos
+	SetStartPosition( GetOrigin() );		// startpos = origin
 }

--- a/src/svgame/entities/base/SVGBaseMover.h
+++ b/src/svgame/entities/base/SVGBaseMover.h
@@ -57,6 +57,7 @@ public:
     SVGBaseMover(Entity* svEntity);
     virtual ~SVGBaseMover();
 
+    DefineAbstractClass( SVGBaseMover, SVGBaseTrigger );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/base/SVGBaseMover.h
+++ b/src/svgame/entities/base/SVGBaseMover.h
@@ -97,6 +97,10 @@ public:
     const inline vec3_t& GetStartPosition() override {
         return startPosition;
     }
+    // Gets the lip
+    const inline float& GetLip() {
+        return lip;
+    }
 
     //
     // Entity Set Functions.
@@ -121,6 +125,18 @@ public:
     inline void SetStartPosition(const vec3_t& startPosition) {
         this->startPosition = startPosition;
     }
+    // Sets the lip
+    inline void SetLip( const float& lip ) {
+        this->lip = lip;
+    }
+
+protected:
+    // Calculates and returns the destination point
+    // ASSUMES: startPosition and moveDirection are set properly
+    vec3_t CalculateEndPosition();
+
+    // Swaps startPosition and endPosition, using the origin as an intermediary
+    void SwapPositions();
 
 protected:
 
@@ -143,6 +159,8 @@ protected:
     vec3_t endPosition;
     // BaseMover moveInfo.
     PushMoveInfo moveInfo;
+    // How far away to stop, from the destination
+    float		lip{ 0.0f };
     // Kill target when triggered.
     //std::string killTargetStr;
 

--- a/src/svgame/entities/base/SVGBaseTrigger.cpp
+++ b/src/svgame/entities/base/SVGBaseTrigger.cpp
@@ -65,7 +65,7 @@ SVGBaseTrigger::~SVGBaseTrigger() {
 //===============
 //
 void SVGBaseTrigger::Precache() {
-	SVGBaseEntity::Precache();
+	Base::Precache();
 }
 
 //
@@ -75,9 +75,7 @@ void SVGBaseTrigger::Precache() {
 //===============
 //
 void SVGBaseTrigger::Spawn() {
-	SVGBaseEntity::Spawn();
-
-
+	Base::Spawn();
 }
 
 //
@@ -87,7 +85,7 @@ void SVGBaseTrigger::Spawn() {
 //===============
 //
 void SVGBaseTrigger::Respawn() {
-	SVGBaseEntity::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -97,7 +95,7 @@ void SVGBaseTrigger::Respawn() {
 //===============
 //
 void SVGBaseTrigger::PostSpawn() {
-	SVGBaseEntity::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -107,7 +105,7 @@ void SVGBaseTrigger::PostSpawn() {
 //===============
 //
 void SVGBaseTrigger::Think() {
-	SVGBaseEntity::Think();
+	Base::Think();
 }
 
 //
@@ -162,7 +160,7 @@ void SVGBaseTrigger::SpawnKey(const std::string& key, const std::string& value) 
 	}
 	// Parent class spawnkey.
 	else {
-		SVGBaseEntity::SpawnKey(key, value);
+		Base::SpawnKey(key, value);
 	}
 }
 

--- a/src/svgame/entities/base/SVGBaseTrigger.cpp
+++ b/src/svgame/entities/base/SVGBaseTrigger.cpp
@@ -186,9 +186,7 @@ void SVGBaseTrigger::UseTargets(SVGBaseEntity* activator) {
 	//
     if (GetDelayTime()) {
 		// Create a temporary DelayedTrigger entity, to fire at a latter time.
-	    Entity *serverTriggerDelay = SVG_Spawn();
-		serverTriggerDelay->className = "DelayedUse";
-		SVGBaseTrigger *triggerDelay = (SVGBaseTrigger*)(serverTriggerDelay->classEntity = SVG_SpawnClassEntity(serverTriggerDelay, "DelayedUse"));
+	    SVGBaseTrigger *triggerDelay = SVG_CreateEntity<TriggerDelayedUse>();
 		if (!activator)
 			gi.DPrintf("TriggerDelayThink with no activator\n");
 		triggerDelay->SetActivator(activator);

--- a/src/svgame/entities/base/SVGBaseTrigger.h
+++ b/src/svgame/entities/base/SVGBaseTrigger.h
@@ -18,6 +18,7 @@ public:
     SVGBaseTrigger(Entity* svEntity);
     virtual ~SVGBaseTrigger();
 
+    DefineAbstractClass( SVGBaseTrigger, SVGBaseEntity );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/func/FuncButton.cpp
+++ b/src/svgame/entities/func/FuncButton.cpp
@@ -29,23 +29,18 @@ FuncButton::FuncButton( Entity* svEntity )
 // FuncButton::Precache
 //===============
 void FuncButton::Precache() {
-	SVGBaseMover::Precache();
+	Base::Precache();
 }
 
 //===============
 // FuncButton::Spawn
 //===============
 void FuncButton::Spawn() {
-	SVGBaseMover::Spawn();
+	Base::Spawn();
 
-	vec3_t absoluteMovedir;
-	float distance;
-	vec3_t angles = GetAngles();
-
-	SetMoveDirection( angles );
-	
 	// Mappers set angles to determine the movement direction of the button,
-	// so we gotta zero the entity's angles
+	// so we gotta set the movement direction, then zero the entity's angles
+	SetMoveDirection( GetAngles() );
 	SetAngles( vec3_zero() );
 
 	SetModel( GetModel() );
@@ -113,7 +108,7 @@ void FuncButton::SpawnKey( const std::string& key, const std::string& value ) {
 	} else if ( key == "lip" ) {
 		ParseFloatKeyValue( key, value, lip );
 	} else {
-		return SVGBaseMover::SpawnKey( key, value );
+		return Base::SpawnKey( key, value );
 	}
 }
 
@@ -229,7 +224,7 @@ void FuncButton::BrushMoveDone() {
 }
 
 //===============
-// SVGBaseMover::BrushMoveFinal
+// Base::BrushMoveFinal
 //===============
 void FuncButton::BrushMoveFinal() {
 	// We've traveled our world, time to rest
@@ -246,7 +241,7 @@ void FuncButton::BrushMoveFinal() {
 }
 
 //===============
-// SVGBaseMover::BrushMoveBegin
+// Base::BrushMoveBegin
 //===============
 void FuncButton::BrushMoveBegin() {
 	float frames;
@@ -267,7 +262,7 @@ void FuncButton::BrushMoveBegin() {
 }
 
 //===============
-// SVGBaseMover::BrushMoveCalc
+// Base::BrushMoveCalc
 //===============
 void FuncButton::BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function ) {
 	PushMoveInfo& mi = moveInfo;

--- a/src/svgame/entities/func/FuncButton.cpp
+++ b/src/svgame/entities/func/FuncButton.cpp
@@ -56,31 +56,24 @@ void FuncButton::Spawn() {
 	if ( GetSound() != 1 ) {
 		moveInfo.startSoundIndex = gi.SoundIndex( "switches/butn2.wav" );
 	} // If the mapper didn't specify speed, set it to 40 u/s
-	if ( !serverEntity->speed ) {
-		serverEntity->speed = 40.0f;
+	if ( !GetSpeed() ) {
+		SetSpeed( 40.0f );
 	} // If the mapper didn't specify acceleration & deceleration, set the defaults
-	if ( !serverEntity->acceleration ) {
-		serverEntity->acceleration = serverEntity->speed;
+	if ( !GetAcceleration() ) {
+		SetAcceleration( GetSpeed() );
 	}
-	if ( !serverEntity->deceleration ) {
-		serverEntity->deceleration = serverEntity->speed;
+	if ( !GetDeceleration() ) {
+		SetDeceleration( GetSpeed() );
 	} // If the mapper didn't specify 'wait until return', then default to 3 seconds
-	if ( !waitTime ) {
+	if ( !GetWaitTime() ) {
 		SetWaitTime( 3.0f );
 	} // Lip: how much to subtract from the door's travel distance
-	if ( !lip ) {
-		lip = 4.0f;
+	if ( !GetLip() ) {
+		SetLip( 8.0f );
 	}
-
 	// Set up the trajectory
-	serverEntity->position1 = GetOrigin();
-
-	absoluteMovedir.x = fabsf( moveDirection.x );
-	absoluteMovedir.y = fabsf( moveDirection.y );
-	absoluteMovedir.z = fabsf( moveDirection.z );
-	distance = (absoluteMovedir.x * serverEntity->size.x) + (absoluteMovedir.y * serverEntity->size.y) + (absoluteMovedir.z * serverEntity->size.z) - lip;
-	
-	serverEntity->position2 = vec3_fmaf( serverEntity->position1, distance, moveDirection );
+	SetStartPosition( GetOrigin() );
+	SetEndPosition( CalculateEndPosition() );
 
 	SetEffects( EntityEffectType::AnimCycleFrames01hz2 );
 
@@ -97,13 +90,13 @@ void FuncButton::Spawn() {
 	// Set up moveInfo stuff
 	// Button starts off
 	moveInfo.state			= MoverState::Bottom;
-	moveInfo.speed			= serverEntity->speed;
-	moveInfo.acceleration	= serverEntity->acceleration;
-	moveInfo.deceleration	= serverEntity->deceleration;
-	moveInfo.wait			= waitTime;
-	moveInfo.startOrigin	= serverEntity->position1;
+	moveInfo.speed			= GetSpeed();
+	moveInfo.acceleration	= GetAcceleration();
+	moveInfo.deceleration	= GetDeceleration();
+	moveInfo.wait			= GetWaitTime();
+	moveInfo.startOrigin	= GetStartPosition();
 	moveInfo.startAngles	= GetAngles();
-	moveInfo.endOrigin		= serverEntity->position2;
+	moveInfo.endOrigin		= GetEndPosition();
 	moveInfo.endAngles		= GetAngles();
 
 	LinkEntity();

--- a/src/svgame/entities/func/FuncButton.cpp
+++ b/src/svgame/entities/func/FuncButton.cpp
@@ -17,17 +17,26 @@
 
 #include "FuncButton.h"
 
+//===============
+// FuncButton::ctor
+//===============
 FuncButton::FuncButton( Entity* svEntity )
 	: SVGBaseMover( svEntity )
 {
 
 }
 
+//===============
+// FuncButton::dtor
+//===============
 void FuncButton::Precache()
 {
 	SVGBaseMover::Precache();
 }
 
+//===============
+// FuncButton::Spawn
+//===============
 void FuncButton::Spawn()
 {
 	SVGBaseMover::Spawn();
@@ -119,6 +128,9 @@ void FuncButton::Spawn()
 	LinkEntity();
 }
 
+//===============
+// FuncButton::SpawnKey
+//===============
 void FuncButton::SpawnKey( const std::string& key, const std::string& value )
 {
 	// I think serverEntity variables should just be set in SVGBaseEntity::SpawnKey
@@ -137,12 +149,18 @@ void FuncButton::SpawnKey( const std::string& key, const std::string& value )
 	}
 }
 
+//===============
+// FuncButton::OnButtonDone
+//===============
 void FuncButton::OnButtonDone( Entity* self )
 {
-	FuncButton* button = static_cast<FuncButton*>( self->classEntity );
+	FuncButton* button = static_cast<FuncButton*>(self->classEntity);
 	button->ButtonDone();
 }
 
+//===============
+// FuncButton::ButtonDone
+//===============
 void FuncButton::ButtonDone()
 {
 	moveInfo.state = MoverState::Bottom;
@@ -150,24 +168,33 @@ void FuncButton::ButtonDone()
 	serverEntity->state.effects |= EntityEffectType::AnimCycleFrames01hz2;
 }
 
+//===============
+// FuncButton::ButtonReturn
+//===============
 void FuncButton::ButtonReturn()
 {
 	moveInfo.state = MoverState::Down;
 	BrushMoveCalc( moveInfo.startOrigin, OnButtonDone );
 	SetFrame( 0 );
-	
+
 	if ( GetHealth() )
 	{
 		SetTakeDamage( TakeDamage::Yes );
 	}
 }
 
+//===============
+// FuncButton::OnButtonWait
+//===============
 void FuncButton::OnButtonWait( Entity* self )
 {
 	FuncButton* button = static_cast<FuncButton*>(self->classEntity);
 	button->ButtonWait();
 }
 
+//===============
+// FuncButton::ButtonWait
+//===============
 void FuncButton::ButtonWait()
 {
 	moveInfo.state = MoverState::Top;
@@ -175,7 +202,7 @@ void FuncButton::ButtonWait()
 	serverEntity->state.effects |= EntityEffectType::AnimCycleFrames23hz2;
 	SetFrame( 1 );
 
-	UseTargets(GetActivator());
+	UseTargets( GetActivator() );
 
 	if ( moveInfo.wait >= 0.0f )
 	{
@@ -184,6 +211,9 @@ void FuncButton::ButtonWait()
 	}
 }
 
+//===============
+// FuncButton::ButtonFire
+//===============
 void FuncButton::ButtonFire()
 {
 	if ( moveInfo.state == MoverState::Up || moveInfo.state == MoverState::Top )
@@ -200,12 +230,18 @@ void FuncButton::ButtonFire()
 	BrushMoveCalc( moveInfo.endOrigin, OnButtonWait );
 }
 
+//===============
+// FuncButton::ButtonUse
+//===============
 void FuncButton::ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator )
 {
 	this->activator = activator;
 	ButtonFire();
 }
 
+//===============
+// FuncButton::ButtonTouch
+//===============
 void FuncButton::ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf )
 {
 	if ( !other->GetClient() || other->GetHealth() <= 0 )
@@ -217,6 +253,9 @@ void FuncButton::ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_
 	ButtonFire();
 }
 
+//===============
+// FuncButton::ButtonDie
+//===============
 void FuncButton::ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, int damage, const vec3_t& point )
 {
 	activator = attacker;
@@ -225,7 +264,7 @@ void FuncButton::ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, i
 }
 
 // =========================
-// Brush move methods
+// FuncButton::BrushMoveDone
 // 
 // Will be moved to either SVGBaseEntity or 
 // some sorta SVGBaseMover when we make one
@@ -236,6 +275,9 @@ void FuncButton::BrushMoveDone()
 	moveInfo.OnEndFunction( serverEntity );
 }
 
+//===============
+// SVGBaseMover::BrushMoveFinal
+//===============
 void FuncButton::BrushMoveFinal()
 {
 	// We've traveled our world, time to rest
@@ -252,6 +294,9 @@ void FuncButton::BrushMoveFinal()
 	SetNextThinkTime( level.time + FRAMETIME );
 }
 
+//===============
+// SVGBaseMover::BrushMoveBegin
+//===============
 void FuncButton::BrushMoveBegin()
 {
 	float frames;
@@ -272,6 +317,9 @@ void FuncButton::BrushMoveBegin()
 	SetNextThinkTime( level.time + (frames * FRAMETIME) );
 }
 
+//===============
+// SVGBaseMover::BrushMoveCalc
+//===============
 void FuncButton::BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function )
 {
 	PushMoveInfo& mi = moveInfo;

--- a/src/svgame/entities/func/FuncButton.cpp
+++ b/src/svgame/entities/func/FuncButton.cpp
@@ -21,34 +21,31 @@
 // FuncButton::ctor
 //===============
 FuncButton::FuncButton( Entity* svEntity )
-	: SVGBaseMover( svEntity )
-{
+	: SVGBaseMover( svEntity ) {
 
 }
 
 //===============
-// FuncButton::dtor
+// FuncButton::Precache
 //===============
-void FuncButton::Precache()
-{
+void FuncButton::Precache() {
 	SVGBaseMover::Precache();
 }
 
 //===============
 // FuncButton::Spawn
 //===============
-void FuncButton::Spawn()
-{
+void FuncButton::Spawn() {
 	SVGBaseMover::Spawn();
 
 	vec3_t absoluteMovedir;
 	float distance;
-
 	vec3_t angles = GetAngles();
+
 	SetMoveDirection( angles );
 	
-	// mappers set angles to determine the movement direction of the button,
-	// so we gotta set the entity's angles to zero
+	// Mappers set angles to determine the movement direction of the button,
+	// so we gotta zero the entity's angles
 	SetAngles( vec3_zero() );
 
 	SetModel( GetModel() );
@@ -56,33 +53,22 @@ void FuncButton::Spawn()
 	SetSolid( Solid::BSP );
 
 	// If the mapper didn't specify a sound
-	if ( GetSound() != 1 )
-	{
+	if ( GetSound() != 1 ) {
 		moveInfo.startSoundIndex = gi.SoundIndex( "switches/butn2.wav" );
-	}
-	// If the mapper didn't specify speed, set it to 40 u/s
-	if ( !serverEntity->speed )
-	{
+	} // If the mapper didn't specify speed, set it to 40 u/s
+	if ( !serverEntity->speed ) {
 		serverEntity->speed = 40.0f;
-	}
-	// If the mapper didn't specify acceleration & deceleration, set the default
-	if ( !serverEntity->acceleration )
-	{
+	} // If the mapper didn't specify acceleration & deceleration, set the defaults
+	if ( !serverEntity->acceleration ) {
 		serverEntity->acceleration = serverEntity->speed;
 	}
-	if ( !serverEntity->deceleration )
-	{
+	if ( !serverEntity->deceleration ) {
 		serverEntity->deceleration = serverEntity->speed;
-	}
-
-	if ( !waitTime )
-	{
+	} // If the mapper didn't specify 'wait until return', then default to 3 seconds
+	if ( !waitTime ) {
 		SetWaitTime( 3.0f );
-	}
-
-	// Lip: how much to subtract from the door's travel distance
-	if ( !lip )
-	{
+	} // Lip: how much to subtract from the door's travel distance
+	if ( !lip ) {
 		lip = 4.0f;
 	}
 
@@ -98,14 +84,11 @@ void FuncButton::Spawn()
 
 	SetEffects( EntityEffectType::AnimCycleFrames01hz2 );
 
-	if ( GetHealth() )
-	{
+	if ( GetHealth() ) {
 		SetMaxHealth( GetHealth() );
 		SetDieCallback( &FuncButton::ButtonDie );
 		SetTakeDamage( TakeDamage::Yes );
-	}
-	else if ( nullptr == serverEntity->targetName )
-	{
+	} else if ( nullptr == serverEntity->targetName ) {
 		SetTouchCallback( &FuncButton::ButtonTouch );
 	}
 
@@ -113,17 +96,15 @@ void FuncButton::Spawn()
 
 	// Set up moveInfo stuff
 	// Button starts off
-	moveInfo.state = MoverState::Bottom;
-
-	moveInfo.speed = serverEntity->speed;
-	moveInfo.acceleration = serverEntity->acceleration;
-	moveInfo.deceleration = serverEntity->deceleration;
-	moveInfo.wait = waitTime;
-
-	moveInfo.startOrigin = serverEntity->position1;
-	moveInfo.startAngles = GetAngles();
-	moveInfo.endOrigin = serverEntity->position2;
-	moveInfo.endAngles = GetAngles();
+	moveInfo.state			= MoverState::Bottom;
+	moveInfo.speed			= serverEntity->speed;
+	moveInfo.acceleration	= serverEntity->acceleration;
+	moveInfo.deceleration	= serverEntity->deceleration;
+	moveInfo.wait			= waitTime;
+	moveInfo.startOrigin	= serverEntity->position1;
+	moveInfo.startAngles	= GetAngles();
+	moveInfo.endOrigin		= serverEntity->position2;
+	moveInfo.endAngles		= GetAngles();
 
 	LinkEntity();
 }
@@ -131,20 +112,14 @@ void FuncButton::Spawn()
 //===============
 // FuncButton::SpawnKey
 //===============
-void FuncButton::SpawnKey( const std::string& key, const std::string& value )
-{
+void FuncButton::SpawnKey( const std::string& key, const std::string& value ) {
 	// I think serverEntity variables should just be set in SVGBaseEntity::SpawnKey
 	// It doesn't make sense to set them only here, if these variables are available to every entity
-	if ( key == "speed" )
-	{
+	if ( key == "speed" ) {
 		ParseFloatKeyValue( key, value, serverEntity->speed );
-	}
-	else if ( key == "lip" )
-	{
+	} else if ( key == "lip" ) {
 		ParseFloatKeyValue( key, value, lip );
-	}
-	else
-	{
+	} else {
 		return SVGBaseMover::SpawnKey( key, value );
 	}
 }
@@ -152,8 +127,7 @@ void FuncButton::SpawnKey( const std::string& key, const std::string& value )
 //===============
 // FuncButton::OnButtonDone
 //===============
-void FuncButton::OnButtonDone( Entity* self )
-{
+void FuncButton::OnButtonDone( Entity* self ) {
 	FuncButton* button = static_cast<FuncButton*>(self->classEntity);
 	button->ButtonDone();
 }
@@ -161,8 +135,7 @@ void FuncButton::OnButtonDone( Entity* self )
 //===============
 // FuncButton::ButtonDone
 //===============
-void FuncButton::ButtonDone()
-{
+void FuncButton::ButtonDone() {
 	moveInfo.state = MoverState::Bottom;
 	serverEntity->state.effects &= ~(EntityEffectType::AnimCycleFrames23hz2);
 	serverEntity->state.effects |= EntityEffectType::AnimCycleFrames01hz2;
@@ -171,14 +144,12 @@ void FuncButton::ButtonDone()
 //===============
 // FuncButton::ButtonReturn
 //===============
-void FuncButton::ButtonReturn()
-{
+void FuncButton::ButtonReturn() {
 	moveInfo.state = MoverState::Down;
 	BrushMoveCalc( moveInfo.startOrigin, OnButtonDone );
 	SetFrame( 0 );
 
-	if ( GetHealth() )
-	{
+	if ( GetHealth() ) {
 		SetTakeDamage( TakeDamage::Yes );
 	}
 }
@@ -186,8 +157,7 @@ void FuncButton::ButtonReturn()
 //===============
 // FuncButton::OnButtonWait
 //===============
-void FuncButton::OnButtonWait( Entity* self )
-{
+void FuncButton::OnButtonWait( Entity* self ) {
 	FuncButton* button = static_cast<FuncButton*>(self->classEntity);
 	button->ButtonWait();
 }
@@ -195,8 +165,7 @@ void FuncButton::OnButtonWait( Entity* self )
 //===============
 // FuncButton::ButtonWait
 //===============
-void FuncButton::ButtonWait()
-{
+void FuncButton::ButtonWait() {
 	moveInfo.state = MoverState::Top;
 	serverEntity->state.effects &= ~(EntityEffectType::AnimCycleFrames01hz2);
 	serverEntity->state.effects |= EntityEffectType::AnimCycleFrames23hz2;
@@ -204,8 +173,7 @@ void FuncButton::ButtonWait()
 
 	UseTargets( GetActivator() );
 
-	if ( moveInfo.wait >= 0.0f )
-	{
+	if ( moveInfo.wait >= 0.0f ) {
 		SetNextThinkTime( level.time + moveInfo.wait );
 		SetThinkCallback( &FuncButton::ButtonReturn );
 	}
@@ -214,16 +182,13 @@ void FuncButton::ButtonWait()
 //===============
 // FuncButton::ButtonFire
 //===============
-void FuncButton::ButtonFire()
-{
-	if ( moveInfo.state == MoverState::Up || moveInfo.state == MoverState::Top )
-	{
+void FuncButton::ButtonFire() {
+	if ( moveInfo.state == MoverState::Up || moveInfo.state == MoverState::Top ) {
 		return;
 	}
 
 	moveInfo.state = MoverState::Up;
-	if ( moveInfo.startSoundIndex && !(flags & EntityFlags::TeamSlave) )
-	{
+	if ( moveInfo.startSoundIndex && !(flags & EntityFlags::TeamSlave) ) {
 		gi.Sound( serverEntity, CHAN_NO_PHS_ADD + CHAN_VOICE, moveInfo.startSoundIndex, 1, ATTN_STATIC, 0 );
 	}
 	
@@ -233,8 +198,7 @@ void FuncButton::ButtonFire()
 //===============
 // FuncButton::ButtonUse
 //===============
-void FuncButton::ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator )
-{
+void FuncButton::ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator ) {
 	this->activator = activator;
 	ButtonFire();
 }
@@ -242,10 +206,8 @@ void FuncButton::ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator )
 //===============
 // FuncButton::ButtonTouch
 //===============
-void FuncButton::ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf )
-{
-	if ( !other->GetClient() || other->GetHealth() <= 0 )
-	{
+void FuncButton::ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf ) {
+	if ( !other->GetClient() || other->GetHealth() <= 0 ) {
 		return;
 	}
 
@@ -256,8 +218,7 @@ void FuncButton::ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_
 //===============
 // FuncButton::ButtonDie
 //===============
-void FuncButton::ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, int damage, const vec3_t& point )
-{
+void FuncButton::ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, int damage, const vec3_t& point ) {
 	activator = attacker;
 	SetHealth( GetMaxHealth() );
 	SetTakeDamage( TakeDamage::No );
@@ -269,8 +230,7 @@ void FuncButton::ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, i
 // Will be moved to either SVGBaseEntity or 
 // some sorta SVGBaseMover when we make one
 // =========================
-void FuncButton::BrushMoveDone()
-{
+void FuncButton::BrushMoveDone() {
 	SetVelocity( vec3_zero() );
 	moveInfo.OnEndFunction( serverEntity );
 }
@@ -278,11 +238,9 @@ void FuncButton::BrushMoveDone()
 //===============
 // SVGBaseMover::BrushMoveFinal
 //===============
-void FuncButton::BrushMoveFinal()
-{
+void FuncButton::BrushMoveFinal() {
 	// We've traveled our world, time to rest
-	if ( moveInfo.remainingDistance == 0.0f )
-	{
+	if ( moveInfo.remainingDistance == 0.0f ) {
 		BrushMoveDone();
 		return;
 	}
@@ -297,13 +255,11 @@ void FuncButton::BrushMoveFinal()
 //===============
 // SVGBaseMover::BrushMoveBegin
 //===============
-void FuncButton::BrushMoveBegin()
-{
+void FuncButton::BrushMoveBegin() {
 	float frames;
 
 	// It's time to stop
-	if ( (moveInfo.speed * FRAMETIME) >= moveInfo.remainingDistance )
-	{
+	if ( (moveInfo.speed * FRAMETIME) >= moveInfo.remainingDistance ) {
 		BrushMoveFinal();
 		return;
 	}
@@ -320,8 +276,7 @@ void FuncButton::BrushMoveBegin()
 //===============
 // SVGBaseMover::BrushMoveCalc
 //===============
-void FuncButton::BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function )
-{
+void FuncButton::BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function ) {
 	PushMoveInfo& mi = moveInfo;
 
 	SetVelocity( vec3_zero() );
@@ -329,20 +284,14 @@ void FuncButton::BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* 
 	mi.remainingDistance = VectorNormalize( moveInfo.dir );
 	mi.OnEndFunction = function;
 
-	if ( mi.speed == mi.acceleration && mi.speed == mi.deceleration )
-	{
-		if ( level.currentEntity == ((GetFlags() & EntityFlags::TeamSlave) ? GetTeamMasterEntity() : this) )
-		{
+	if ( mi.speed == mi.acceleration && mi.speed == mi.deceleration ) {
+		if ( level.currentEntity == ((GetFlags() & EntityFlags::TeamSlave) ? GetTeamMasterEntity() : this) ) {
 			BrushMoveBegin();
-		}
-		else
-		{
+		} else {
 			SetThinkCallback( &FuncButton::BrushMoveBegin );
 			SetNextThinkTime( level.time + FRAMETIME );
 		}
-	}
-	else
-	{
+	} else {
 		// accelerative
 		mi.currentSpeed = 0;
 

--- a/src/svgame/entities/func/FuncButton.h
+++ b/src/svgame/entities/func/FuncButton.h
@@ -6,8 +6,7 @@ class SVGBaseMover;
 // A standard button, able to trigger entities once pressed,
 // and changes its texture depending on its state
 //===============
-class FuncButton : public SVGBaseMover
-{
+class FuncButton : public SVGBaseMover {
 public:
 	FuncButton( Entity* svEntity );
 	virtual ~FuncButton() = default;
@@ -34,9 +33,6 @@ protected: // Implementation details, should be moved to SVGBaseMover
 	void		BrushMoveFinal();
 	void		BrushMoveBegin();
 	void		BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function );
-
-protected: // Should also be, perhaps, moved to SVGBaseMover
-	float		lip{ 0.0f };
 };
 
 

--- a/src/svgame/entities/func/FuncButton.h
+++ b/src/svgame/entities/func/FuncButton.h
@@ -11,6 +11,8 @@ public:
 	FuncButton( Entity* svEntity );
 	virtual ~FuncButton() = default;
 
+	DefineMapClass( "func_button", FuncButton, SVGBaseMover );
+
 	void		Precache() override;
 	void		Spawn() override;
 	void		SpawnKey( const std::string& key, const std::string& value ) override;

--- a/src/svgame/entities/func/FuncButton.h
+++ b/src/svgame/entities/func/FuncButton.h
@@ -2,36 +2,41 @@
 
 class SVGBaseMover;
 
+//===============
+// A standard button, able to trigger entities once pressed,
+// and changes its texture depending on its state
+//===============
 class FuncButton : public SVGBaseMover
 {
 public:
 	FuncButton( Entity* svEntity );
 	virtual ~FuncButton() = default;
 
-	void Precache() override;
-	void Spawn() override;
-	
-	void SpawnKey( const std::string& key, const std::string& value ) override;
+	void		Precache() override;
+	void		Spawn() override;
+	void		SpawnKey( const std::string& key, const std::string& value ) override;
 
+	// These static methods here are required for mover logic, since the legacy code
+	// we ported simply operates on global functions & function pointers
 	static void OnButtonDone( Entity* self );
-	void ButtonDone();
-	void ButtonReturn();
+	void		ButtonDone(); // The button is done moving, it is fully pressed
+	void		ButtonReturn(); // The button is returning from "pressed" to "sticking out"
 	static void OnButtonWait( Entity* self );
-	void ButtonWait();
-	void ButtonFire();
+	void		ButtonWait(); // The button is waiting for further interactions
+	void		ButtonFire(); // The button has just been pressed, do something
+	
+	void		ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator );
+	void		ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf );
+	void		ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, int damage, const vec3_t& point );
 
-	void ButtonUse( SVGBaseEntity* other, SVGBaseEntity* activator );
-	void ButtonTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf );
-	void ButtonDie( SVGBaseEntity* inflictor, SVGBaseEntity* attacker, int damage, const vec3_t& point );
+protected: // Implementation details, should be moved to SVGBaseMover
+	void		BrushMoveDone();
+	void		BrushMoveFinal();
+	void		BrushMoveBegin();
+	void		BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function );
 
-protected:
-	void BrushMoveDone();
-	void BrushMoveFinal();
-	void BrushMoveBegin();
-	void BrushMoveCalc( const vec3_t& destination, PushMoveEndFunction* function );
-
-protected:
-	float lip{ 0.0f };
+protected: // Should also be, perhaps, moved to SVGBaseMover
+	float		lip{ 0.0f };
 };
 
 

--- a/src/svgame/entities/func/FuncDoor.cpp
+++ b/src/svgame/entities/func/FuncDoor.cpp
@@ -31,7 +31,7 @@ FuncDoor::FuncDoor( Entity* entity )
 // FuncDoor::Precache
 //===============
 void FuncDoor::Precache() {
-    SVGBaseMover::Precache();
+    Base::Precache();
 
     // Set up the default sounds
     if ( GetSound() != 1 ) {
@@ -47,7 +47,7 @@ void FuncDoor::Precache() {
 void FuncDoor::Spawn() {
     vec3_t absoluteMovedir;
 
-    SVGBaseMover::Spawn();
+    Base::Spawn();
 
     SetMoveDirection( GetAngles()/*, resetAngles = true*/ );
     SetMoveType( MoveType::Push );

--- a/src/svgame/entities/func/FuncDoor.cpp
+++ b/src/svgame/entities/func/FuncDoor.cpp
@@ -1,0 +1,247 @@
+/*
+// LICENSE HERE.
+
+// FuncDoor.cpp
+*/
+
+#include "../../g_local.h"
+#include "../../effects.h"
+#include "../../entities.h"
+#include "../../utils.h"
+#include "../../physics/stepmove.h"
+#include "../../brushfuncs.h"
+
+#include "../base/SVGBaseEntity.h"
+#include "../base/SVGBaseTrigger.h"
+#include "../base/SVGBaseMover.h"
+
+#include "../trigger/TriggerAutoDoor.h"
+
+#include "FuncDoor.h"
+
+//===============
+// FuncDoor::ctor
+//===============
+FuncDoor::FuncDoor( Entity* entity ) 
+	: SVGBaseMover( entity ) {
+
+}
+
+//===============
+// FuncDoor::Precache
+//===============
+void FuncDoor::Precache() {
+    SVGBaseMover::Precache();
+
+    // Set up the default sounds
+    if ( GetSound() != 1 ) {
+        moveInfo.startSoundIndex = gi.SoundIndex( "doors/dr1_strt.wav" );
+        moveInfo.middleSoundIndex = gi.SoundIndex( "doors/dr1_mid.wav" );
+        moveInfo.endSoundIndex = gi.SoundIndex( "doors/dr1_end.wav" );
+    }
+}
+
+//===============
+// FuncDoor::Spawn
+//===============
+void FuncDoor::Spawn() {
+    vec3_t absoluteMovedir;
+
+    SVGBaseMover::Spawn();
+
+    SetMoveDirection( GetAngles()/*, resetAngles = true*/ );
+    SetMoveType( MoveType::Push );
+    SetSolid( Solid::BSP );
+    SetModel( GetModel() );
+
+    SetBlockedCallback( nullptr /*DoorBlocked*/ );
+    SetUseCallback( nullptr /*DoorUse*/ );
+
+    if ( !GetSpeed() ) {
+        SetSpeed( 100.0f );
+    }
+    //if ( game.gameMode->IsClass( GameModeDeathmatch::ClassInfo ) ) {
+    //    SetSpeed( GetSpeed() * 2.0f );
+    //}
+    if ( !GetAcceleration() ) {
+        SetAcceleration( GetSpeed() );
+    }
+    if ( !GetDeceleration() ) {
+        SetDeceleration( GetSpeed() );
+    }
+    if ( !GetWaitTime() ) {
+        SetWaitTime( 3.0f );
+    }
+    if ( !GetLip() ) {
+        SetLip( 8.0f );
+    }
+    if ( !GetDamage() ) {
+        SetDamage( 2 );
+    }
+
+    // Calculate the end position, with the assumption that start pos = origin
+    SetStartPosition( GetOrigin() );
+    SetEndPosition( CalculateEndPosition() );
+
+    // If it starts open, swap the positions
+    if ( GetSpawnFlags() & FuncDoor::SF_StartOpen ) {
+        SwapPositions();
+    }
+
+    moveInfo.state = MoverState::Bottom;
+
+    // If the mapper specified health, then make this door
+    // openable by shooting it
+    if ( GetHealth() ) {
+        SetTakeDamage( TakeDamage::Yes );
+        SetDieCallback( nullptr /*DoorKilled*/ );
+        SetMaxHealth( GetHealth() );
+    } else if ( nullptr == serverEntity->targetName ) {
+        gi.SoundIndex( "misc/talk.wav" ); // ???
+        SetTouchCallback( nullptr /*DoorTouch*/ );
+    }
+
+    moveInfo.speed = GetSpeed();
+    moveInfo.acceleration = GetAcceleration();
+    moveInfo.deceleration = GetDeceleration();
+    moveInfo.wait = GetWaitTime();
+    moveInfo.startOrigin = GetStartPosition();
+    moveInfo.startAngles = GetAngles();
+    moveInfo.endOrigin = GetEndPosition();
+    moveInfo.endAngles = GetAngles();
+
+    if ( GetSpawnFlags() & SF_Toggle ) {
+        serverEntity->state.effects |= EntityEffectType::AnimCycleAll2hz;
+    }
+    if ( GetSpawnFlags() & SF_YAxis ) {
+        serverEntity->state.effects |= EntityEffectType::AnimCycleAll30hz;
+    }
+
+    // To simplify logic elsewhere, make non-teamed doors into a team of one
+    if ( !GetTeam() ) {
+        SetTeamMasterEntity( this );
+    }
+
+    LinkEntity();
+}
+
+//===============
+// FuncDoor::PostSpawn
+// 
+// func_door in Q2 originally used spawn think functions
+// to achieve this. If the entity had health or had a 
+// targetname, it'd calculate its move speed, else
+// it'd spawn a door trigger around itself
+//===============
+void FuncDoor::PostSpawn() {
+    if ( GetHealth() || !targetNameStr.empty() ) {
+        CalculateMoveSpeed();
+    } else {
+        SpawnDoorTrigger();
+    }
+}
+
+//===============
+// FuncDoor::CalculateMoveSpeed
+//===============
+void FuncDoor::CalculateMoveSpeed() {
+    if ( GetFlags() & EntityFlags::TeamSlave ) {
+        return; // Only the team master does this
+    }
+
+    FuncDoor* ent = nullptr;
+    float min;
+    float time;
+    float newSpeed;
+    float ratio;
+    float distance;
+    
+    // Find the smallest any member of the team will be moving
+    min = fabsf( moveInfo.distance );
+    for ( ent = dynamic_cast<FuncDoor*>( GetTeamChainEntity() ); ent; ent = dynamic_cast<FuncDoor*>( ent->GetTeamChainEntity() ) ) {
+        distance = fabsf( ent->moveInfo.distance );
+        if ( distance < min ) {
+            min = distance;
+        }
+    }
+
+    time = min / GetSpeed();
+
+    // Adjust speeds so they will all complete at the same time
+    for ( ent = this; ent; ent = dynamic_cast<FuncDoor*>(ent->GetTeamChainEntity()) ) {
+        newSpeed = fabsf( ent->moveInfo.distance ) / time;
+        ratio = newSpeed / ent->moveInfo.speed;
+
+        if ( ent->moveInfo.acceleration == ent->moveInfo.speed ) {
+            ent->moveInfo.acceleration = newSpeed;
+        } else {
+            ent->moveInfo.acceleration *= ratio;
+        }
+
+        if ( ent->moveInfo.deceleration == ent->moveInfo.speed ) {
+            ent->moveInfo.deceleration = ent->moveInfo.speed;
+        } else {
+            ent->moveInfo.deceleration *= ratio;
+        }
+
+        // Update moveInfo variables and class member variables
+        ent->SetAcceleration( ent->moveInfo.acceleration );
+        ent->SetDeceleration( ent->moveInfo.deceleration );
+        ent->moveInfo.speed = newSpeed;
+        ent->SetSpeed( newSpeed );
+    }
+}
+
+//===============
+// FuncDoor::SpawnDoorTrigger
+// 
+// Nameless, non-shootable doors have an invisible bounding box around them, which
+// is slightly larger than the door's bounding box.
+// 
+// This bad boy spawns it, so keep that in mind if you're running out of edict slots.
+//===============
+void FuncDoor::SpawnDoorTrigger() {
+    FuncDoor* teamMember = nullptr;
+    SVGBaseEntity* trigger = nullptr;
+    vec3_t mins = GetMins();
+    vec3_t maxs = GetMaxs();
+
+    if ( GetFlags() & EntityFlags::TeamSlave ) {
+        return; // Only the team leader spawns a trigger
+    }
+    
+    for ( teamMember = dynamic_cast<FuncDoor*>(GetTeamChainEntity()); teamMember; teamMember = dynamic_cast<FuncDoor*>(teamMember->GetTeamChainEntity()) ) {
+        AddPointToBounds( teamMember->GetAbsoluteMin(), mins, maxs );
+        AddPointToBounds( teamMember->GetAbsoluteMax(), mins, maxs );
+    }
+
+    // Expand the trigger box on the horizontal plane by 60 units
+    static const vec3_t HullExpand = { 60.0f, 60.0f, 0.0f };
+    mins -= HullExpand;
+    maxs += HullExpand;
+
+    // Spawn the auto door trigger
+    trigger = TriggerAutoDoor::Create( this, maxs, mins );
+    
+    if ( GetSpawnFlags() & FuncDoor::SF_StartOpen ) {
+        UseAreaportals( true );
+    }
+
+    CalculateMoveSpeed();
+}
+
+//===============
+// FuncDoor::UseAreaportals
+//===============
+void FuncDoor::UseAreaportals( bool open ) const {
+    if ( targetStr.empty() ) {
+        return;
+    }
+
+    SVGBaseEntity* portal = nullptr;
+    while ( portal = SVG_FindEntityByKeyValue( "targetname", targetStr, portal ) ) {
+        if ( std::string( portal->GetClassName() ) == "func_areaportal" ) {
+            gi.SetAreaPortalState( portal->GetStyle(), open );
+        }
+    }
+}

--- a/src/svgame/entities/func/FuncDoor.h
+++ b/src/svgame/entities/func/FuncDoor.h
@@ -5,11 +5,12 @@ class SVGBaseMover;
 //===============
 // A standard, sliding door
 //===============
-class FuncDoor : public SVGBaseMover
-{
+class FuncDoor : public SVGBaseMover {
 public:
     FuncDoor( Entity* entity );
     virtual ~FuncDoor() = default;
+
+    DefineMapClass( "func_door", FuncDoor, SVGBaseMover );
 
     // Spawn flags
     static constexpr int32_t SF_StartOpen   = 1 << 0;

--- a/src/svgame/entities/func/FuncDoor.h
+++ b/src/svgame/entities/func/FuncDoor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+class SVGBaseMover;
+
+//===============
+// A standard, sliding door
+//===============
+class FuncDoor : public SVGBaseMover
+{
+public:
+    FuncDoor( Entity* entity );
+    virtual ~FuncDoor() = default;
+
+    // Spawn flags
+    static constexpr int32_t SF_StartOpen   = 1 << 0;
+    static constexpr int32_t SF_Reverse     = 1 << 1;
+    static constexpr int32_t SF_Crusher     = 1 << 2;
+    static constexpr int32_t SF_NoMonsters  = 1 << 3;
+    static constexpr int32_t SF_Toggle      = 1 << 4;
+    static constexpr int32_t SF_XAxis       = 1 << 5;
+    static constexpr int32_t SF_YAxis       = 1 << 6;
+
+    void		Precache() override;
+	void		Spawn() override;
+    void        PostSpawn() override;
+	//void		SpawnKey( const std::string& key, const std::string& value ) override;
+
+protected:
+    void        CalculateMoveSpeed();
+    void        SpawnDoorTrigger();
+    void        UseAreaportals( bool open ) const;
+};

--- a/src/svgame/entities/info/InfoPlayerStart.cpp
+++ b/src/svgame/entities/info/InfoPlayerStart.cpp
@@ -13,7 +13,8 @@
 #include "InfoPlayerStart.h"            // Class.
 
 // Constructor/Deconstructor.
-InfoPlayerStart::InfoPlayerStart(Entity* svEntity) : SVGBaseEntity(svEntity) {
+InfoPlayerStart::InfoPlayerStart(Entity* svEntity) 
+    : SVGBaseEntity(svEntity) {
 
 }
 InfoPlayerStart::~InfoPlayerStart() {
@@ -22,18 +23,18 @@ InfoPlayerStart::~InfoPlayerStart() {
 
 // Interface functions. 
 void InfoPlayerStart::Precache() {
-    SVGBaseEntity::Precache();
+    Base::Precache();
 }
 
 void InfoPlayerStart::Spawn() {
-    SVGBaseEntity::Spawn();
+    Base::Spawn();
 }
 
 void InfoPlayerStart::PostSpawn() {
-    SVGBaseEntity::PostSpawn();
+    Base::PostSpawn();
 }
 
 void InfoPlayerStart::Think() {
     // Parent think.
-    SVGBaseEntity::Think();
+    Base::Think();
 }

--- a/src/svgame/entities/info/InfoPlayerStart.h
+++ b/src/svgame/entities/info/InfoPlayerStart.h
@@ -17,6 +17,8 @@ public:
     InfoPlayerStart(Entity* svEntity);
     virtual ~InfoPlayerStart();
 
+    DefineMapClass( "info_player_start", InfoPlayerStart, SVGBaseEntity );
+
     // Interface functions. 
     void Precache();    // Precaches data.
     void Spawn();       // Spawns the entity.

--- a/src/svgame/entities/light.cpp
+++ b/src/svgame/entities/light.cpp
@@ -26,11 +26,11 @@ Light::~Light() {
 // Interface functions. 
 void Light::Precache() {
     // Parent class precache.
-    SVGBaseTrigger::Precache();
+    Base::Precache();
 }
 void Light::Spawn() {
     // Parent class spawn.
-    SVGBaseTrigger::Spawn();
+    Base::Spawn();
 
     // WatIsDeze: I think we want lights. This is for the old 1997/1998
     // no targeted lights in deathmatch, because they cause global messages
@@ -54,11 +54,11 @@ void Light::Spawn() {
 }
 void Light::PostSpawn() {
     // Parent class PostSpawn.
-    SVGBaseTrigger::PostSpawn();
+    Base::PostSpawn();
 }
 void Light::Think() {
     // Parent class think.
-    SVGBaseTrigger::Think();
+    Base::Think();
 }
 
 void Light::LightUse(SVGBaseEntity* other, SVGBaseEntity* activator) {

--- a/src/svgame/entities/misc/MiscExplosionBox.cpp
+++ b/src/svgame/entities/misc/MiscExplosionBox.cpp
@@ -23,7 +23,8 @@
 //
 // Constructor/Deconstructor.
 //
-MiscExplosionBox::MiscExplosionBox(Entity* svEntity) : SVGBaseTrigger(svEntity) {
+MiscExplosionBox::MiscExplosionBox(Entity* svEntity) 
+    : SVGBaseTrigger(svEntity) {
 
 }
 MiscExplosionBox::~MiscExplosionBox() {
@@ -43,7 +44,7 @@ MiscExplosionBox::~MiscExplosionBox() {
 //
 void MiscExplosionBox::Precache() {
     // Always call parent class method.
-    SVGBaseTrigger::Precache();
+    Base::Precache();
 
     // Precache actual barrel model.
     SVG_PrecacheModel("models/objects/barrels/tris.md2");
@@ -64,7 +65,7 @@ void MiscExplosionBox::Precache() {
 //
 void MiscExplosionBox::Spawn() {
     // Always call parent class method.
-    SVGBaseTrigger::Spawn();
+    Base::Spawn();
 
     // Set solid.
     SetSolid(Solid::BoundingBox);
@@ -138,7 +139,7 @@ void MiscExplosionBox::Respawn() {
 //
 void MiscExplosionBox::PostSpawn() {
     // Always call parent class method.
-    SVGBaseTrigger::PostSpawn();
+    Base::PostSpawn();
 	//gi.DPrintf("MiscExplosionBox::PostSpawn();");
 }
 
@@ -150,7 +151,7 @@ void MiscExplosionBox::PostSpawn() {
 //
 void MiscExplosionBox::Think() {
     // Always call parent class method.
-    SVGBaseTrigger::Think();
+    Base::Think();
 
 	//gi.DPrintf("MiscExplosionBox::Think();");
 }

--- a/src/svgame/entities/misc/MiscExplosionBox.h
+++ b/src/svgame/entities/misc/MiscExplosionBox.h
@@ -18,6 +18,8 @@ public:
     MiscExplosionBox(Entity* svEntity);
     virtual ~MiscExplosionBox();
 
+    DefineMapClass( "misc_explobox", MiscExplosionBox, SVGBaseTrigger );
+
     //
     // Interface functions. 
     //

--- a/src/svgame/entities/trigger/TriggerAlways.cpp
+++ b/src/svgame/entities/trigger/TriggerAlways.cpp
@@ -45,7 +45,7 @@ TriggerAlways::~TriggerAlways() {
 //===============
 //
 void TriggerAlways::Precache() {
-	SVGBaseTrigger::Precache();
+	Base::Precache();
 }
 
 //
@@ -56,7 +56,7 @@ void TriggerAlways::Precache() {
 //
 void TriggerAlways::Spawn() {
 	// Spawn base trigger.
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 	// Initialize Brush Trigger.
 	InitPointTrigger();
@@ -79,7 +79,7 @@ void TriggerAlways::Spawn() {
 //===============
 //
 void TriggerAlways::Respawn() {
-	SVGBaseTrigger::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -89,7 +89,7 @@ void TriggerAlways::Respawn() {
 //===============
 //
 void TriggerAlways::PostSpawn() {
-	SVGBaseTrigger::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -99,13 +99,13 @@ void TriggerAlways::PostSpawn() {
 //===============
 //
 void TriggerAlways::Think() {
-	SVGBaseTrigger::Think();
+	Base::Think();
 }
 
 void TriggerAlways::SpawnKey(const std::string& key, const std::string& value) {
 	// Parent class spawnkey.
 	// We don't want it to reposition this fucker.?
-	SVGBaseTrigger::SpawnKey(key, value);
+	Base::SpawnKey(key, value);
 }
 
 //

--- a/src/svgame/entities/trigger/TriggerAlways.h
+++ b/src/svgame/entities/trigger/TriggerAlways.h
@@ -18,6 +18,7 @@ public:
     TriggerAlways(Entity* svEntity);
     virtual ~TriggerAlways();
 
+    DefineMapClass( "trigger_always", TriggerAlways, SVGBaseTrigger );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/trigger/TriggerAutoDoor.cpp
+++ b/src/svgame/entities/trigger/TriggerAutoDoor.cpp
@@ -44,6 +44,9 @@ void TriggerAutoDoor::Spawn() {
 //===============
 void TriggerAutoDoor::AutoDoorTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf ) {
 	bool isMonster = other->GetServerFlags() & EntityServerFlags::Monster;
+	// Alternatively, when we have a BaseMonster class:
+	// isMonster = other->IsSubclassOf<BaseMonster>();
+
 	if ( other->GetHealth() <= 0 ) {
 		return; // If you're dead, you can't pass
 	}
@@ -68,7 +71,7 @@ void TriggerAutoDoor::AutoDoorTouch( SVGBaseEntity* self, SVGBaseEntity* other, 
 // TriggerAutoDoor::Create
 //===============
 TriggerAutoDoor* TriggerAutoDoor::Create( SVGBaseEntity* ownerEntity, vec3_t ownerMaxs, vec3_t ownerMins ) {
-	TriggerAutoDoor* autoDoor = static_cast<TriggerAutoDoor*>(SVG_SpawnClassEntity( SVG_Spawn(), "trigger_auto_door" ));
+	TriggerAutoDoor* autoDoor = SVG_CreateEntity<TriggerAutoDoor>();
 	autoDoor->SetOwner( ownerEntity );
 	autoDoor->SetMaxs( ownerMaxs );
 	autoDoor->SetMins( ownerMins );

--- a/src/svgame/entities/trigger/TriggerAutoDoor.cpp
+++ b/src/svgame/entities/trigger/TriggerAutoDoor.cpp
@@ -1,0 +1,76 @@
+/*
+// LICENSE HERE.
+
+// TriggerAutoDoor.cpp
+*/
+
+#include "../../g_local.h"
+#include "../../effects.h"
+#include "../../entities.h"
+#include "../../utils.h"
+#include "../../physics/stepmove.h"
+#include "../../brushfuncs.h"
+
+#include "../base/SVGBaseEntity.h"
+#include "../base/SVGBaseTrigger.h"
+#include "../base/SVGBaseMover.h"
+
+#include "../func/FuncDoor.h"
+
+#include "TriggerAutoDoor.h"
+
+//===============
+// TriggerAutoDoor::ctor
+//===============
+TriggerAutoDoor::TriggerAutoDoor( Entity* entity )
+	: SVGBaseTrigger( entity ) {
+	debounceTouchTime = 0.0f;
+}
+
+//===============
+// TriggerAutoDoor::Spawn
+//===============
+void TriggerAutoDoor::Spawn() {
+	SVGBaseTrigger::Spawn();
+
+	SetSolid( Solid::Trigger );
+	SetMoveType( MoveType::None );
+	SetTouchCallback( &TriggerAutoDoor::AutoDoorTouch );
+	LinkEntity();
+}
+
+//===============
+// TriggerAutoDoor::AutoDoorTouch
+//===============
+void TriggerAutoDoor::AutoDoorTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf ) {
+	bool isMonster = other->GetServerFlags() & EntityServerFlags::Monster;
+	if ( other->GetHealth() <= 0 ) {
+		return; // If you're dead, you can't pass
+	}
+	// Only players and monsters are allowed
+	if ( !(isMonster) && (!other->GetClient()) ) {
+		return;
+	}
+	// Unless the no monster flag is set
+	if ( (GetOwner()->GetSpawnFlags() & FuncDoor::SF_NoMonsters) && (isMonster) ) {
+		return;
+	}
+	// If it's not the time to activate the door yet, then don't
+	if ( level.time < debounceTouchTime ) {
+		return;
+	}
+	debounceTouchTime = level.time + 1.0f;
+	// Trigger our door
+	GetOwner()->Use( other, other );
+}
+
+//===============
+// TriggerAutoDoor::Create
+//===============
+TriggerAutoDoor* TriggerAutoDoor::Create( SVGBaseEntity* ownerEntity, vec3_t ownerMaxs, vec3_t ownerMins ) {
+	TriggerAutoDoor* autoDoor = static_cast<TriggerAutoDoor*>(SVG_SpawnClassEntity( SVG_Spawn(), "trigger_auto_door" ));
+	autoDoor->SetOwner( ownerEntity );
+	autoDoor->SetMaxs( ownerMaxs );
+	autoDoor->SetMins( ownerMins );
+	autoDoor->Spawn();
+}

--- a/src/svgame/entities/trigger/TriggerAutoDoor.cpp
+++ b/src/svgame/entities/trigger/TriggerAutoDoor.cpp
@@ -31,7 +31,7 @@ TriggerAutoDoor::TriggerAutoDoor( Entity* entity )
 // TriggerAutoDoor::Spawn
 //===============
 void TriggerAutoDoor::Spawn() {
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 	SetSolid( Solid::Trigger );
 	SetMoveType( MoveType::None );
@@ -73,4 +73,5 @@ TriggerAutoDoor* TriggerAutoDoor::Create( SVGBaseEntity* ownerEntity, vec3_t own
 	autoDoor->SetMaxs( ownerMaxs );
 	autoDoor->SetMins( ownerMins );
 	autoDoor->Spawn();
+	return autoDoor;
 }

--- a/src/svgame/entities/trigger/TriggerAutoDoor.h
+++ b/src/svgame/entities/trigger/TriggerAutoDoor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+class SVGBaseTrigger;
+
+//===============
+// Automatic trigger for func_door
+//===============
+class TriggerAutoDoor : public SVGBaseTrigger {
+public:
+	TriggerAutoDoor( Entity* entity );
+	virtual ~TriggerAutoDoor() = default;
+
+	void					Spawn() override;
+	// Responds to players touching this trigger
+	void					AutoDoorTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf );
+	// Creates an automatic door trigger and sets everything up for it
+	static TriggerAutoDoor* Create( SVGBaseEntity* ownerEntity, vec3_t ownerMaxs, vec3_t ownerMins );
+
+protected:
+	float					debounceTouchTime;
+};

--- a/src/svgame/entities/trigger/TriggerAutoDoor.h
+++ b/src/svgame/entities/trigger/TriggerAutoDoor.h
@@ -10,6 +10,8 @@ public:
 	TriggerAutoDoor( Entity* entity );
 	virtual ~TriggerAutoDoor() = default;
 
+	DefineClass( TriggerAutoDoor, SVGBaseTrigger );
+
 	void					Spawn() override;
 	// Responds to players touching this trigger
 	void					AutoDoorTouch( SVGBaseEntity* self, SVGBaseEntity* other, cplane_t* plane, csurface_t* surf );

--- a/src/svgame/entities/trigger/TriggerDelayedUse.cpp
+++ b/src/svgame/entities/trigger/TriggerDelayedUse.cpp
@@ -24,7 +24,8 @@
 // 
 
 // Constructor/Deconstructor.
-TriggerDelayedUse::TriggerDelayedUse(Entity* svEntity) : SVGBaseTrigger(svEntity) {
+TriggerDelayedUse::TriggerDelayedUse(Entity* svEntity) 
+	: SVGBaseTrigger(svEntity) {
 	//
 	// All callback functions best be nullptr.
 	//
@@ -50,7 +51,7 @@ TriggerDelayedUse::~TriggerDelayedUse() {
 //===============
 //
 void TriggerDelayedUse::Precache() {
-	SVGBaseTrigger::Precache();
+	Base::Precache();
 }
 
 //
@@ -61,7 +62,7 @@ void TriggerDelayedUse::Precache() {
 //
 void TriggerDelayedUse::Spawn() {
 	// Spawn base trigger.
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 	// Initialize Brush Trigger.
 	//InitPointTrigger();
@@ -79,7 +80,7 @@ void TriggerDelayedUse::Spawn() {
 //===============
 //
 void TriggerDelayedUse::Respawn() {
-	SVGBaseTrigger::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -89,7 +90,7 @@ void TriggerDelayedUse::Respawn() {
 //===============
 //
 void TriggerDelayedUse::PostSpawn() {
-	SVGBaseTrigger::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -99,7 +100,7 @@ void TriggerDelayedUse::PostSpawn() {
 //===============
 //
 void TriggerDelayedUse::Think() {
-	SVGBaseTrigger::Think();
+	Base::Think();
 }
 
 //
@@ -111,7 +112,7 @@ void TriggerDelayedUse::Think() {
 void TriggerDelayedUse::SpawnKey(const std::string& key, const std::string& value) {
 	// Parent class spawnkey.
 	// We don't want it to reposition this fucker.?
-	SVGBaseTrigger::SpawnKey(key, value);
+	Base::SpawnKey(key, value);
 }
 
 //

--- a/src/svgame/entities/trigger/TriggerDelayedUse.h
+++ b/src/svgame/entities/trigger/TriggerDelayedUse.h
@@ -18,6 +18,7 @@ public:
     TriggerDelayedUse(Entity* svEntity);
     virtual ~TriggerDelayedUse();
 
+    DefineClass( TriggerDelayedUse, SVGBaseTrigger );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/trigger/TriggerHurt.cpp
+++ b/src/svgame/entities/trigger/TriggerHurt.cpp
@@ -49,7 +49,7 @@ TriggerHurt::~TriggerHurt() {
 //===============
 //
 void TriggerHurt::Precache() {
-	SVGBaseTrigger::Precache();
+	Base::Precache();
 }
 
 //
@@ -60,7 +60,7 @@ void TriggerHurt::Precache() {
 //
 void TriggerHurt::Spawn() {
 	// Spawn base trigger.
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 	// Initialize Brush Trigger.
 	InitBrushTrigger();
@@ -95,7 +95,7 @@ void TriggerHurt::Spawn() {
 //===============
 //
 void TriggerHurt::Respawn() {
-	SVGBaseTrigger::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -105,7 +105,7 @@ void TriggerHurt::Respawn() {
 //===============
 //
 void TriggerHurt::PostSpawn() {
-	SVGBaseTrigger::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -115,7 +115,7 @@ void TriggerHurt::PostSpawn() {
 //===============
 //
 void TriggerHurt::Think() {
-	SVGBaseTrigger::Think();
+	Base::Think();
 }
 
 void TriggerHurt::SpawnKey(const std::string& key, const std::string& value) {
@@ -125,7 +125,7 @@ void TriggerHurt::SpawnKey(const std::string& key, const std::string& value) {
 	if (key == "origin") {
 
 	} else {
-		SVGBaseTrigger::SpawnKey(key, value);
+		Base::SpawnKey(key, value);
 	}
 }
 
@@ -209,12 +209,12 @@ void TriggerHurt::TriggerHurtUse(SVGBaseEntity* other, SVGBaseEntity* activator)
 
 //
 //===============
-// SVGBaseTrigger::Use
+// Base::Use
 //
 // Execute the 'Use' callback in case we ran into any.
 //===============
 //
-//void SVGBaseTrigger::Use(SVGBaseEntity* other, SVGBaseEntity* activator) {
+//void Base::Use(SVGBaseEntity* other, SVGBaseEntity* activator) {
 //	// Safety check.
 //	if (useFunction == nullptr)
 //		return;

--- a/src/svgame/entities/trigger/TriggerHurt.h
+++ b/src/svgame/entities/trigger/TriggerHurt.h
@@ -18,6 +18,7 @@ public:
     TriggerHurt(Entity* svEntity);
     virtual ~TriggerHurt();
 
+    DefineMapClass( "trigger_hurt", TriggerHurt, SVGBaseTrigger );
 
     //
     // Interface functions. 
@@ -44,7 +45,7 @@ public:
 
 protected:
     //
-    // Other base entity members. (These were old fields in edict_T back in the day.)
+    // Other base entity members. (These were old fields in edict_t back in the day.)
     //
     // The time this entity has last been hurting anyone else. It is used for the slow damage flag.
     float lastHurtTime;

--- a/src/svgame/entities/trigger/TriggerMultiple.cpp
+++ b/src/svgame/entities/trigger/TriggerMultiple.cpp
@@ -45,7 +45,7 @@ TriggerMultiple::~TriggerMultiple() {
 //===============
 //
 void TriggerMultiple::Precache() {
-	SVGBaseTrigger::Precache();
+	Base::Precache();
 }
 
 //
@@ -56,7 +56,7 @@ void TriggerMultiple::Precache() {
 //
 void TriggerMultiple::Spawn() {
 	// Spawn base trigger.
-	SVGBaseTrigger::Spawn();
+	Base::Spawn();
 
 	// Initialize Brush Trigger.
 	InitBrushTrigger();
@@ -92,7 +92,7 @@ void TriggerMultiple::Spawn() {
 //===============
 //
 void TriggerMultiple::Respawn() {
-	SVGBaseTrigger::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -102,7 +102,7 @@ void TriggerMultiple::Respawn() {
 //===============
 //
 void TriggerMultiple::PostSpawn() {
-	SVGBaseTrigger::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -112,7 +112,7 @@ void TriggerMultiple::PostSpawn() {
 //===============
 //
 void TriggerMultiple::Think() {
-	SVGBaseTrigger::Think();
+	Base::Think();
 }
 
 //
@@ -124,7 +124,7 @@ void TriggerMultiple::Think() {
 void TriggerMultiple::SpawnKey(const std::string& key, const std::string& value) {
 	// Parent class spawnkey.
 	// We don't want it to reposition this fucker.?
-	SVGBaseTrigger::SpawnKey(key, value);
+	Base::SpawnKey(key, value);
 }
 
 void TriggerMultiple::Trigger(SVGBaseEntity *activator) {

--- a/src/svgame/entities/trigger/TriggerMultiple.h
+++ b/src/svgame/entities/trigger/TriggerMultiple.h
@@ -18,6 +18,7 @@ public:
     TriggerMultiple(Entity* svEntity);
     virtual ~TriggerMultiple();
 
+    DefineMapClass( "trigger_multiple", TriggerMultiple, SVGBaseTrigger );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/trigger/TriggerOnce.cpp
+++ b/src/svgame/entities/trigger/TriggerOnce.cpp
@@ -46,7 +46,7 @@ TriggerOnce::~TriggerOnce() {
 //===============
 //
 void TriggerOnce::Precache() {
-	TriggerMultiple::Precache();
+	Base::Precache();
 }
 
 //
@@ -57,7 +57,7 @@ void TriggerOnce::Precache() {
 //
 void TriggerOnce::Spawn() {
 	// Spawn base trigger.
-	TriggerMultiple::Spawn();
+	Base::Spawn();
 
 	// Set wait time to -1... (So it triggers only once.)
 	SetWaitTime(-1.f);
@@ -70,7 +70,7 @@ void TriggerOnce::Spawn() {
 //===============
 //
 void TriggerOnce::Respawn() {
-	TriggerMultiple::Respawn();
+	Base::Respawn();
 }
 
 //
@@ -80,7 +80,7 @@ void TriggerOnce::Respawn() {
 //===============
 //
 void TriggerOnce::PostSpawn() {
-	TriggerMultiple::PostSpawn();
+	Base::PostSpawn();
 }
 
 //
@@ -90,7 +90,7 @@ void TriggerOnce::PostSpawn() {
 //===============
 //
 void TriggerOnce::Think() {
-	TriggerMultiple::Think();
+	Base::Think();
 }
 
 //
@@ -106,13 +106,13 @@ void TriggerOnce::SpawnKey(const std::string& key, const std::string& value) {
 	} else {
 		// Parent class spawnkey.
 		// We don't want it to reposition this fucker.?
-		TriggerMultiple::SpawnKey(key, value);
+		Base::SpawnKey(key, value);
 	}
 }
 
 void TriggerOnce::Trigger(SVGBaseEntity* activator) {
 	// Parent trigger.
-	TriggerMultiple::Trigger(activator);
+	Base::Trigger(activator);
 }
 
 //

--- a/src/svgame/entities/trigger/TriggerOnce.h
+++ b/src/svgame/entities/trigger/TriggerOnce.h
@@ -18,6 +18,7 @@ public:
     TriggerOnce(Entity* svEntity);
     virtual ~TriggerOnce();
 
+    DefineMapClass( "trigger_once", TriggerOnce, TriggerMultiple );
 
     //
     // Interface functions. 

--- a/src/svgame/entities/weaponry/BlasterBolt.cpp
+++ b/src/svgame/entities/weaponry/BlasterBolt.cpp
@@ -19,7 +19,8 @@
 #include "BlasterBolt.h"
 
 // Constructor/Deconstructor.
-BlasterBolt::BlasterBolt(Entity* svEntity) : SVGBaseEntity(svEntity) {
+BlasterBolt::BlasterBolt(Entity* svEntity) 
+    : SVGBaseEntity(svEntity) {
 
 }
 BlasterBolt::~BlasterBolt() {
@@ -33,7 +34,7 @@ BlasterBolt::~BlasterBolt() {
 //===============
 //
 void BlasterBolt::Precache() {
-    SVGBaseEntity::Precache();
+    Base::Precache();
 }
 
 //
@@ -44,7 +45,7 @@ void BlasterBolt::Precache() {
 //
 void BlasterBolt::Spawn() {
     // Spawn.
-    SVGBaseEntity::Spawn();
+    Base::Spawn();
 }
 
 //
@@ -64,7 +65,7 @@ void BlasterBolt::Respawn() {
 //===============
 //
 void BlasterBolt::PostSpawn() {
-    SVGBaseEntity::PostSpawn();
+    Base::PostSpawn();
 }
 
 //
@@ -75,7 +76,7 @@ void BlasterBolt::PostSpawn() {
 //
 void BlasterBolt::Think() {
     // Parent class Think.
-    SVGBaseEntity::Think();
+    Base::Think();
 }
 
 //
@@ -87,7 +88,7 @@ void BlasterBolt::Think() {
 //
 void BlasterBolt::SpawnKey(const std::string& key, const std::string& value) {
     // Parent class spawnkey.
-    SVGBaseEntity::SpawnKey(key, value);
+    Base::SpawnKey(key, value);
 }
 
 //

--- a/src/svgame/entities/weaponry/BlasterBolt.h
+++ b/src/svgame/entities/weaponry/BlasterBolt.h
@@ -17,6 +17,8 @@ public:
     BlasterBolt(Entity* svEntity);
     virtual ~BlasterBolt();
 
+    DefineClass( BlasterBolt, SVGBaseEntity );
+
     //
     // Interface functions. 
     //

--- a/src/svgame/main.cpp
+++ b/src/svgame/main.cpp
@@ -144,6 +144,9 @@ void SVG_InitGame(void)
     // WID: Informed consent. One has to know, right? :D
     gi.DPrintf("==== InitServerGame ====\n");
 
+    // Initialise the type info system
+    TypeInfo::SetupSuperClasses();
+
     // Initialize and allocate core objects for this "games" map 'round'.
     SVG_InitializeCVars();
     SVG_InitItems();

--- a/src/svgame/weapons.cpp
+++ b/src/svgame/weapons.cpp
@@ -354,12 +354,17 @@ void SVG_FireBlaster(SVGBaseEntity *self, const vec3_t& start, const vec3_t &aim
     vec3_t dir = vec3_normalize(aimdir);
  
     // Spawn the blaster bolt server entity.
-    Entity *serverEntity = SVG_Spawn();
-    serverEntity->className = "BlasterBolt";
+    BlasterBolt* boltEntity = SVG_CreateEntity<BlasterBolt>();
 
-    // Enjoy its class entity.
-    BlasterBolt *boltEntity = (BlasterBolt*)(serverEntity->classEntity = SVG_SpawnClassEntity(serverEntity, "BlasterBolt"));
-    
+    // Welp. It can happen sometimes
+    if ( nullptr == boltEntity ) {
+        return;
+    }
+
+    // Admer: TODO: perform this setup directly in BlasterBolt, e.g.
+    // BlasterBolt::Create( start, aimdir, damage, speed, effect, hyper );
+    // This stuff down there is... really rotten
+
     // Basic attributes.
     boltEntity->Precache();
     boltEntity->Spawn();
@@ -389,7 +394,7 @@ void SVG_FireBlaster(SVGBaseEntity *self, const vec3_t& start, const vec3_t &aim
     boltEntity->SetTouchCallback(&BlasterBolt::BlasterBoltTouch);
 
     // Set think.
-    boltEntity->SetNextThinkTime(level.time + 2);
+    boltEntity->SetNextThinkTime(level.time + 2); // Admer: should this really be a thing?
     boltEntity->SetThinkCallback(&SVGBaseEntity::SVGBaseEntityThinkFree);
 
     // Link Bolt into world.


### PR DESCRIPTION
This is a relatively big PR. It includes the following:

- func_door draft (will be finalised in one of the following PRs)
- shaders are no longer required to compile, if the user is only compiling with the OpenGL backend
- updated, reformatted FuncButton and comments
- TypeInfo class, a modified ClassEntityInfo from BurekTech, so we can easily get runtime information about entity (and other) classes
- spawn procedures like ED_CallSpawn have been overhauled for the new TypeInfo system
- I wrote an SVG_CreateEntity template function, so we can just go `FuncDoor* door = SVG_CreateEntity<FuncDoor>();` instead of a complicated setup involving an Entity pointer and stuff
- macros for TypeInfo, so we can easily define TypeInfos in entity classes

So, what's different now?

*Entity spawning*
```cpp
FuncDoor* door = SVG_CreateEntity<FuncDoor>();
door->Precache();
door->Spawn();
door->PostSpawn();
```

*Entity class bodies*
```cpp
class FuncDoor : public SVGBaseMover {
public:
    FuncDoor( Entity* entity );
    virtual ~FuncDoor() = default;

    DefineMapClass( "func_door", FuncDoor, SVGBaseMover );
...
```
For abstract and base classes, we have `DefineAbstractClass( SVGBaseMover, SVGBaseEntity );`, and for classes that aren't meant to be spawned in the map (only via code), we have `DefineClass( BlasterBolt, SVGBaseSomething );`.
`DefineClass` can be used for any class, and the system supports multiple class trees. So for example, you could have one class tree for entities, another for gamemodes, and another one for something else, as needed.

SVG_SpawnClassEntity then looks up each TypeInfo and compares map classname strings (func_door) to the current keyvalue classname.